### PR TITLE
restrict Container::get() return type

### DIFF
--- a/src/REST/AbstractRoute.php
+++ b/src/REST/AbstractRoute.php
@@ -33,6 +33,11 @@ abstract class AbstractRoute implements RouteInterface
         return $this->namespace;
     }
 
+    public function setNamespace(string $namespace) : void
+    {
+        $this->namespace = $namespace;
+    }
+
     public function getRouteRegex(): string
     {
         if (isset($this->routeRegex)) {

--- a/src/REST/Route.php
+++ b/src/REST/Route.php
@@ -39,7 +39,7 @@ class Route
                 }
                 // namespace をセットする必要があるのでこのタイミングで初期化する
                 $routeObject = $container->get($class);
-                $routeObject->namespace = $apiNamespace;
+                $routeObject->setNamespace($apiNamespace);
                 $container->bind($class, $routeObject);
                 if (!isset($routes[$apiNamespace])) {
                     $routes[$apiNamespace] = [];

--- a/src/REST/RouteInterface.php
+++ b/src/REST/RouteInterface.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 interface RouteInterface
 {
     public function getNamespace(): string;
+    public function setNamespace(string $namespace): void;
     public function getRouteRegex(): string;
     public function getMethods(): string;
     public function invoke(RequestInterface $request): ResponseInterface;

--- a/tests/DiTest.php
+++ b/tests/DiTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Test\Resta;
+
+use Error;
+use Exception;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TypeError;
+use Wp\Resta\DI\Container;
+
+class Sample {}
+class Sample2 {}
+interface SampleInterface {}
+class Sample3 implements SampleInterface {}
+
+class DiTest extends TestCase
+{
+    public function testAutowiring()
+    {
+        $container = Container::getInstance();
+        $container->bind(Sample::class);
+        $this->assertEquals(new Sample, $container->get(Sample::class));
+    }
+
+    public function testObjectBind()
+    {
+        $container = Container::getInstance();
+        $container->bind(Sample::class, new Sample);
+        $this->assertEquals(new Sample, $container->get(Sample::class));
+        $this->assertNotSame(new Sample, $container->get(Sample::class));
+    }
+
+    public function testProviderBinding()
+    {
+        $container = Container::getInstance();
+        $container->bind(Sample::class, function () {
+            return new Sample;
+        });
+        $this->assertEquals(new Sample, $container->get(Sample::class));
+        $this->assertNotSame($container->get(Sample::class), $container->get(Sample::class));
+    }
+
+    public function testDoNotResolveOtherType()
+    {
+        $container = Container::getInstance();
+        $container->bind(Sample::class, function () {
+            return new Sample2;
+        });
+        $this->expectException(Exception::class);
+        $container->get(Sample::class);
+    }
+
+    public function testDoNotResolveClassDoesNotExist()
+    {
+        $container = Container::getInstance();
+        $container->bind(Sample::class, 'DoNotExistClass');
+        $this->expectException(Exception::class);
+        $container->get(Sample::class);
+    }
+
+    public function testCannotBindArray()
+    {
+        $container = Container::getInstance();
+        $this->expectException(TypeError::class);
+        $container->bind(Sample::class, ['this', 'is', 'array']); // @phpstan-ignore-line
+    }
+
+    public function testOnlyBindInterfaceShouldFail()
+    {
+        $container = Container::getInstance();
+        $container->bind(SampleInterface::class);
+        $this->expectException(Error::class);
+        $container->get(SampleInterface::class);
+    }
+
+    public function testBindInterfaceToImplementation()
+    {
+        $container = Container::getInstance();
+        $container->unbind(SampleInterface::class);
+        $container->bind(SampleInterface::class, Sample3::class);
+        $this->assertEquals(new Sample3, $container->get(SampleInterface::class));
+    }
+}


### PR DESCRIPTION
Do not allow `Container::get()` return array or string or etc. It should return resolved class or interface.