### PR TITLE
Route クラスの callback の return type からスキーマを推測する

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ composer test:e2e
 
 wp-resta は OpenAPI 3.0 によるスキーマ定義をサポートしています。ルートクラスで定義したスキーマは自動的に OpenAPI 仕様として出力され、Swagger UI でドキュメント化されます。
 
+**スキーマ定義の詳細**: wp-resta では複数の方法でスキーマを定義できます。詳しくは [docs/SCHEMA.md](docs/SCHEMA.md) を参照してください。
+- `ObjectType` クラスを使った型安全なスキーマ定義（推奨）
+- PHPDoc の `@return` アノテーションによる自動推論
+- `SCHEMA` 定数による完全な制御（複雑なスキーマ向け）
+
 ### Envelope Pattern
 
 wp-resta では、REST API レスポンスを統一的な構造でラップする**Envelope Pattern**をサポートしています。

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     },
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {
         "szepeviktor/phpstan-wordpress": "^1.3",

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -791,11 +791,16 @@ public int $id;
 
 ### プリミティブ型の配列が推論されない
 
-**原因**: 自動推論はObjectTypeのみ対応
+**原因**: PHPDocなどから配列要素の型（`string` や `int` など）を解決できない
 
-**解決策**: SCHEMA定数を使用
+**解決策**: PHPDocを追加するか、SCHEMA定数で明示的に定義する
 
 ```php
+// PHPDocを付ければ自動推論される
+/** @var string[] */
+public array $tags;
+
+// もしくはSCHEMA定数で明示的に定義する
 public const SCHEMA = [
     'type' => 'array',
     'items' => ['type' => 'string'],

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,814 @@
+# スキーマ定義ガイド
+
+wp-restaでは、REST APIのレスポンススキーマを定義することで、自動的にOpenAPI 3.0仕様を生成し、Swagger UIでドキュメント化できます。
+
+## 目次
+
+- [スキーマ定義の3つの方法](#スキーマ定義の3つの方法)
+- [ObjectType - オブジェクトスキーマ](#objecttype---オブジェクトスキーマ)
+- [自動推論 - PHPDocから自動生成](#自動推論---phpdocから自動生成)
+- [SCHEMA定数 - 完全な制御](#schema定数---完全な制御)
+- [利用可能なJSON Schemaキーワード](#利用可能なjson-schemaキーワード)
+- [ベストプラクティス](#ベストプラクティス)
+
+---
+
+## スキーマ定義の3つの方法
+
+wp-restaでは、以下の3つの方法でスキーマを定義できます：
+
+### 1. ObjectTypeクラス - 単一オブジェクト
+
+型安全で保守性が高く、最もシンプルな方法です。
+
+```php
+class Post extends ObjectType {
+    public function __construct(
+        public int $ID,
+        public string $post_title,
+        public string $post_content,
+    ) {}
+}
+
+// Routeで使用
+public function callback(int $id): Post {
+    return new Post(...);
+}
+```
+
+### 2. PHPDocアノテーション - 配列の自動推論
+
+ObjectTypeの配列やプリミティブ型の配列を返す場合、PHPDocから自動推論されます。
+
+```php
+/**
+ * @return Post[]        // ObjectTypeの配列
+ * @return string[]      // プリミティブ型の配列
+ */
+public function callback(): array {
+    return [...];
+}
+```
+
+### 3. SCHEMA定数 - 完全な制御
+
+複雑なスキーマ（Union型、複雑なネスト、`oneOf`など）や、詳細な制約（`minItems`, `pattern`など）を定義する場合に使用します。
+
+```php
+public const SCHEMA = [
+    'type' => 'array',
+    'items' => ['type' => 'string'],
+    'minItems' => 1,  // 詳細な制約
+    'uniqueItems' => true,
+];
+```
+
+---
+
+## ObjectType - オブジェクトスキーマ
+
+### 基本的な定義
+
+コンストラクタプロモーションを使った定義が最もシンプルです：
+
+```php
+use Wp\Resta\REST\Schemas\ObjectType;
+
+class User extends ObjectType {
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $email,
+        public ?string $bio = null,  // nullable
+    ) {}
+}
+```
+
+生成されるスキーマ：
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {"type": "integer"},
+    "name": {"type": "string"},
+    "email": {"type": "string"},
+    "bio": {"type": "string"}
+  },
+  "required": ["id", "name", "email"],
+  "$id": "#/components/schemas/User"
+}
+```
+
+### 型推論
+
+以下のPHP型が自動的にJSON Schema型に変換されます：
+
+| PHP型 | JSON Schema型 |
+|-------|---------------|
+| `int` | `integer` |
+| `float` | `number` |
+| `string` | `string` |
+| `bool` | `boolean` |
+| `array` | `array` |
+| ObjectType継承クラス | `$ref` |
+
+### metadata() - 追加情報の定義
+
+`description`や`example`などの追加情報を定義できます：
+
+```php
+class User extends ObjectType {
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $email,
+    ) {}
+
+    public static function metadata(): array {
+        return [
+            'id' => [
+                'description' => 'ユーザーID',
+                'example' => 123,
+            ],
+            'name' => [
+                'description' => 'ユーザー名',
+                'example' => '山田太郎',
+                'minLength' => 1,
+                'maxLength' => 100,
+            ],
+            'email' => [
+                'description' => 'メールアドレス',
+                'format' => 'email',
+                'example' => 'yamada@example.com',
+            ],
+        ];
+    }
+}
+```
+
+### カスタムスキーマID
+
+デフォルトでは`#/components/schemas/クラス名`が使われますが、カスタマイズも可能：
+
+```php
+class User extends ObjectType {
+    public const ID = '#/components/schemas/CustomUser';
+
+    // ...
+}
+```
+
+### ネストしたオブジェクト
+
+他のObjectTypeを参照できます：
+
+```php
+class Author extends ObjectType {
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {}
+}
+
+class Post extends ObjectType {
+    public function __construct(
+        public int $id,
+        public string $title,
+        public Author $author,  // 他のObjectTypeを参照
+    ) {}
+}
+```
+
+生成されるスキーマ：
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {"type": "integer"},
+    "title": {"type": "string"},
+    "author": {"$ref": "#/components/schemas/Author"}
+  }
+}
+```
+
+---
+
+## 自動推論 - PHPDocから自動生成
+
+### 単一オブジェクトを返す
+
+`callback`の戻り値の型がObjectTypeのサブクラスの場合、自動的にスキーマが推論されます：
+
+```php
+class GetPost extends AbstractRoute {
+    public function callback(int $id): Post {
+        return new Post(...);
+    }
+}
+```
+
+**SCHEMA定数は不要です！**
+
+### プリミティブ型を返す
+
+`callback`の戻り値の型がプリミティブ型（`string`, `int`, `bool`, `float`）の場合、自動的にスキーマが推論されます：
+
+```php
+class GetMessage extends AbstractRoute {
+    public function callback(): string {
+        return 'Hello, World!';
+    }
+}
+```
+
+生成されるスキーマ：
+
+```json
+{
+  "type": "string"
+}
+```
+
+**対応するプリミティブ型**:
+- `string` → `"type": "string"`
+- `int`, `integer` → `"type": "integer"`
+- `float`, `double` → `"type": "number"`
+- `bool`, `boolean` → `"type": "boolean"`
+
+**nullable型（`?string`など）**:
+
+```php
+class GetOptionalMessage extends AbstractRoute {
+    public function callback(): ?string {
+        return null;
+    }
+}
+```
+
+生成されるスキーマ：
+
+```json
+{
+  "anyOf": [
+    {"type": "string"},
+    {"type": "null"}
+  ]
+}
+```
+
+### 配列を返す
+
+PHPDocを使って配列の要素型を指定すると、自動的にスキーマが推論されます：
+
+#### ObjectTypeの配列
+
+**パターン1: `Type[]`形式**
+
+```php
+class GetPosts extends AbstractRoute {
+    /**
+     * @return Post[]
+     */
+    public function callback(): array {
+        return array_map(fn($wp_post) => new Post(...), $posts);
+    }
+}
+```
+
+**パターン2: `array<Type>`形式**
+
+```php
+/**
+ * @return array<Post>
+ */
+public function callback(): array {
+    return [...];
+}
+```
+
+**パターン3: `array<string, Type>`形式**
+
+```php
+/**
+ * @return array<string, Post>
+ */
+public function callback(): array {
+    return ['featured' => $post1, 'recent' => $post2];
+}
+```
+
+生成されるスキーマ：
+
+```json
+{
+  "type": "array",
+  "items": {
+    "$ref": "#/components/schemas/Post"
+  }
+}
+```
+
+#### プリミティブ型の配列
+
+**対応するプリミティブ型**: `string`, `int`, `integer`, `float`, `double`, `bool`, `boolean`
+
+**パターン1: `type[]`形式**
+
+```php
+class GetTags extends AbstractRoute {
+    /**
+     * @return string[]
+     */
+    public function callback(): array {
+        return ['WordPress', 'REST API', 'PHP'];
+    }
+}
+```
+
+**パターン2: `array<type>`形式**
+
+```php
+/**
+ * @return array<int>
+ */
+public function callback(): array {
+    return [1, 2, 3];
+}
+```
+
+**パターン3: `array<int, type>`形式**
+
+```php
+/**
+ * @return array<string, float>
+ */
+public function callback(): array {
+    return ['price' => 29.99, 'tax' => 2.40];
+}
+```
+
+生成されるスキーマ（例: string[]の場合）：
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}
+```
+
+### use文の自動解決
+
+短縮名（`Post`）は自動的に完全修飾名（`Wp\Resta\REST\Example\Schemas\Post`）に解決されます：
+
+```php
+use Wp\Resta\REST\Example\Schemas\Post;
+
+class GetPosts extends AbstractRoute {
+    /**
+     * @return Post[]  // ← 自動的に完全修飾名に解決される
+     */
+    public function callback(): array {
+        return [...];
+    }
+}
+```
+
+以下の形式に対応：
+- 基本形式: `use Foo\Bar\Baz;`
+- エイリアス: `use Foo\Bar\Baz as Qux;`
+- グループuse: `use Foo\Bar\{Baz, Qux};`
+
+### 自動推論の対応範囲
+
+自動推論は以下に対応しています：
+- **ObjectTypeのサブクラス**（単一オブジェクトまたは配列）
+- **プリミティブ型**（`string`, `int`, `bool`, `float`, および nullable型）
+- **プリミティブ型の配列**（`string[]`, `int[]`, `array<bool>`など）
+
+以下のケースではSCHEMA定数が必要です：
+
+- Union型（`Post|string`など、ただし nullable型 `?string` は対応済み）
+- 複雑なネスト構造（オブジェクトの中に配列、など）
+- `oneOf`/`anyOf`/`allOf`（nullable型以外）
+- `additionalProperties`などの高度な機能
+- 詳細な制約（`minItems`, `maxItems`, `pattern`, `format`など）
+
+→ 詳細は「[SCHEMA定数 - 完全な制御](#schema定数---完全な制御)」を参照
+
+---
+
+## SCHEMA定数 - 完全な制御
+
+`SCHEMA`定数を使うと、OpenAPI仕様のあらゆる機能を使用できます。
+
+### プリミティブ型の配列（明示的な定義）
+
+プリミティブ型の配列は`@return string[]`などのPHPDocで自動推論されますが、より詳細な制御（例: `minItems`, `maxItems`, `uniqueItems`など）が必要な場合はSCHEMA定数を使用できます：
+
+```php
+class GetTags extends AbstractRoute {
+    protected const ROUTE = 'tags';
+
+    public const SCHEMA = [
+        'type' => 'array',
+        'items' => ['type' => 'string'],
+        'minItems' => 1,
+        'maxItems' => 10,
+        'uniqueItems' => true,
+    ];
+
+    /**
+     * @return string[]
+     */
+    public function callback(): array {
+        return ['WordPress', 'REST API', 'PHP'];
+    }
+}
+```
+
+### 複数の型（Union型）
+
+```php
+class GetResource extends AbstractRoute {
+    public const SCHEMA = [
+        'oneOf' => [
+            ['$ref' => '#/components/schemas/Post'],
+            ['type' => 'string'],
+            ['type' => 'null'],
+        ],
+    ];
+
+    public function callback(int $id): Post|string|null {
+        // ...
+    }
+}
+```
+
+### 複雑なネスト構造
+
+```php
+class GetGroupedPosts extends AbstractRoute {
+    public const SCHEMA = [
+        'type' => 'object',
+        'properties' => [
+            'featured' => [
+                'type' => 'array',
+                'items' => ['$ref' => '#/components/schemas/Post'],
+            ],
+            'recent' => [
+                'type' => 'array',
+                'items' => ['$ref' => '#/components/schemas/Post'],
+            ],
+        ],
+    ];
+
+    public function callback(): array {
+        return [
+            'featured' => [...],
+            'recent' => [...],
+        ];
+    }
+}
+```
+
+### additionalPropertiesの使用
+
+```php
+class GetMetadata extends AbstractRoute {
+    public const SCHEMA = [
+        'type' => 'object',
+        'additionalProperties' => ['type' => 'string'],
+    ];
+
+    public function callback(): array {
+        return [
+            'key1' => 'value1',
+            'key2' => 'value2',
+            // 動的なキー
+        ];
+    }
+}
+```
+
+### allOf/anyOfの使用
+
+```php
+class GetExtendedPost extends AbstractRoute {
+    public const SCHEMA = [
+        'allOf' => [
+            ['$ref' => '#/components/schemas/Post'],
+            [
+                'type' => 'object',
+                'properties' => [
+                    'view_count' => ['type' => 'integer'],
+                    'likes' => ['type' => 'integer'],
+                ],
+            ],
+        ],
+    ];
+
+    // ...
+}
+```
+
+### 数値の範囲指定
+
+```php
+class GetScore extends AbstractRoute {
+    public const SCHEMA = [
+        'type' => 'object',
+        'properties' => [
+            'score' => [
+                'type' => 'integer',
+                'minimum' => 0,
+                'maximum' => 100,
+            ],
+        ],
+    ];
+
+    // ...
+}
+```
+
+---
+
+## 利用可能なJSON Schemaキーワード
+
+`metadata()`や`SCHEMA`定数で指定できる主なキーワード：
+
+### 文字列関連
+
+```php
+'email' => [
+    'type' => 'string',
+    'format' => 'email',       // email, uri, uuid, date, date-time など
+    'pattern' => '^[a-z]+$',   // 正規表現
+    'minLength' => 5,          // 最小文字列長
+    'maxLength' => 100,        // 最大文字列長
+    'enum' => ['draft', 'published', 'archived'],  // 列挙型
+]
+```
+
+### 数値関連
+
+```php
+'age' => [
+    'type' => 'integer',
+    'minimum' => 0,            // 最小値
+    'maximum' => 120,          // 最大値
+    'exclusiveMinimum' => 0,   // 排他的最小値
+    'multipleOf' => 5,         // 倍数
+]
+```
+
+### 配列関連
+
+```php
+'tags' => [
+    'type' => 'array',
+    'items' => ['type' => 'string'],
+    'minItems' => 1,           // 最小要素数
+    'maxItems' => 10,          // 最大要素数
+    'uniqueItems' => true,     // 要素の一意性
+]
+```
+
+### オブジェクト関連
+
+```php
+'metadata' => [
+    'type' => 'object',
+    'properties' => [...],
+    'required' => ['id'],
+    'additionalProperties' => false,  // 追加プロパティを許可しない
+]
+```
+
+### スキーマ組み合わせ
+
+```php
+'value' => [
+    'oneOf' => [              // いずれか1つ
+        ['type' => 'string'],
+        ['type' => 'integer'],
+    ],
+    'anyOf' => [...],         // いずれか1つ以上
+    'allOf' => [...],         // すべて
+    'not' => [...],           // 否定
+]
+```
+
+### その他
+
+```php
+'status' => [
+    'type' => 'string',
+    'default' => 'draft',      // デフォルト値
+    'deprecated' => true,      // 非推奨フラグ (OpenAPI)
+    'readOnly' => true,        // 読み取り専用 (OpenAPI)
+    'writeOnly' => true,       // 書き込み専用 (OpenAPI)
+    'title' => 'Status',       // タイトル
+    'description' => '...',    // 説明
+    'example' => 'draft',      // 例示値
+    'examples' => ['draft', 'published'],  // 複数の例示値
+]
+```
+
+---
+
+## ベストプラクティス
+
+### ✅ DO: シンプルなケースは自動推論を使う
+
+```php
+// Good: ObjectType + 自動推論
+class GetPost extends AbstractRoute {
+    public function callback(int $id): Post {
+        return new Post(...);
+    }
+}
+```
+
+```php
+// Good: ObjectTypeの配列
+/**
+ * @return Post[]
+ */
+public function callback(): array {
+    return [...];
+}
+```
+
+### ✅ DO: 複雑なケースはSCHEMA定数を使う
+
+```php
+// Good: プリミティブ型の配列
+public const SCHEMA = [
+    'type' => 'array',
+    'items' => ['type' => 'string'],
+];
+```
+
+### ✅ DO: コンストラクタプロモーションと名前付き引数を使う
+
+```php
+// Good: 簡潔で読みやすい
+return new Post(
+    ID: $wp_post->ID,
+    post_title: $wp_post->post_title,
+    post_content: $wp_post->post_content,
+);
+```
+
+### ✅ DO: metadata()で追加情報を定義する
+
+```php
+// Good: 型定義とメタデータが分離
+class User extends ObjectType {
+    public function __construct(
+        public string $email,
+    ) {}
+
+    public static function metadata(): array {
+        return [
+            'email' => [
+                'format' => 'email',
+                'example' => 'user@example.com',
+            ],
+        ];
+    }
+}
+```
+
+### ✅ DO: スキーマクラスはクリーンに保つ
+
+```php
+// Good: データ構造の定義のみ
+class Post extends ObjectType {
+    public function __construct(
+        public int $ID,
+        public string $post_title,
+    ) {}
+}
+
+// Route側でマッピング
+class GetPost extends AbstractRoute {
+    public function callback(int $id): Post {
+        $wp_post = get_post($id);
+        return new Post(
+            ID: $wp_post->ID,
+            post_title: $wp_post->post_title,
+        );
+    }
+}
+```
+
+### ✅ DO: nullable型を適切に使う
+
+```php
+// Good: nullableを明示
+public function __construct(
+    public int $id,              // 必須
+    public ?string $bio = null,  // オプション
+) {}
+```
+
+これにより、`bio`は自動的に`required`から除外されます。
+
+### ❌ DON'T: 自動推論できないケースで無理にObjectTypeを使わない
+
+```php
+// Bad: string[]のためだけにObjectTypeを作る
+class StringList extends ArrayType { /* ... */ }
+```
+
+```php
+// Good: SCHEMA定数を使う
+public const SCHEMA = [
+    'type' => 'array',
+    'items' => ['type' => 'string'],
+];
+```
+
+---
+
+## 選択のガイドライン
+
+### ObjectType + 自動推論を使うべき場合
+
+- ✅ 単一のオブジェクトを返す
+- ✅ ObjectTypeのサブクラスの配列を返す
+- ✅ ネストしたObjectTypeを返す
+
+### SCHEMA定数を使うべき場合
+
+- ✅ プリミティブ型の配列（`string[]`, `int[]`など）
+- ✅ Union型（`Post|string`）
+- ✅ `oneOf`/`anyOf`/`allOf`が必要
+- ✅ `additionalProperties`などの高度な機能が必要
+- ✅ 複雑なネスト構造
+- ✅ OpenAPI仕様の全機能を活用したい
+
+---
+
+## トラブルシューティング
+
+### スキーマが推論されない
+
+**原因**: PHPDocのクラス名が解決できない
+
+**解決策**: use文を追加するか、完全修飾名を使用
+
+```php
+// 解決策1: use文を追加
+use Wp\Resta\REST\Example\Schemas\Post;
+
+/** @return Post[] */
+```
+
+```php
+// 解決策2: 完全修飾名を使用
+/** @return \Wp\Resta\REST\Example\Schemas\Post[] */
+```
+
+### プロパティがrequiredにならない
+
+**原因**: nullable型になっている
+
+**解決策**: `?`を外す
+
+```php
+// requiredにならない
+public ?int $id;
+
+// requiredになる
+public int $id;
+```
+
+### プリミティブ型の配列が推論されない
+
+**原因**: 自動推論はObjectTypeのみ対応
+
+**解決策**: SCHEMA定数を使用
+
+```php
+public const SCHEMA = [
+    'type' => 'array',
+    'items' => ['type' => 'string'],
+];
+```
+
+---
+
+## まとめ
+
+- **シンプルなケース**: ObjectType + 自動推論
+- **複雑なケース**: SCHEMA定数
+- **保守性**: 型推論により、PHPの型とスキーマが自動的に同期
+- **柔軟性**: metadata()やSCHEMA定数で詳細な定義も可能
+
+詳細な実装例は`src/REST/Example/`ディレクトリを参照してください。

--- a/src/REST/Example/Routes/Post.php
+++ b/src/REST/Example/Routes/Post.php
@@ -18,17 +18,7 @@ class Post extends AbstractRoute
         'id' => 'integer',
     ];
 
-    public const SCHEMA = [
-        'type' => 'object',
-        'properties' => [
-            'post' => ['$ref' => SchemasPost::ID]
-        ]
-    ];
-
-    /**
-     * @return array<string, SchemasPost>|null
-     */
-    public function callback(int $id) : ?array
+    public function callback(int $id): ?SchemasPost
     {
         $post = get_post($id);
         if ($post === null) {
@@ -36,8 +26,15 @@ class Post extends AbstractRoute
             return null;
         }
 
-        return [
-            'post' => new SchemasPost($post)
-        ];
+        return new SchemasPost(
+            ID: $post->ID,
+            post_author: $post->post_author,
+            post_date: $post->post_date,
+            post_date_gmt: $post->post_date_gmt,
+            post_content: $post->post_content,
+            post_title: $post->post_title,
+            post_status: $post->post_status,
+            post_name: $post->post_name,
+        );
     }
 }

--- a/src/REST/Example/Routes/Posts.php
+++ b/src/REST/Example/Routes/Posts.php
@@ -11,13 +11,6 @@ class Posts extends AbstractRoute
 {
     protected const ROUTE = 'posts';
 
-    public const SCHEMA = [
-        'type' => 'array',
-        'items' => [
-            '$ref' => Post::ID
-        ],
-    ];
-
     /**
      * @return Post[]
      */

--- a/src/REST/Example/Routes/Posts.php
+++ b/src/REST/Example/Routes/Posts.php
@@ -32,8 +32,15 @@ class Posts extends AbstractRoute
             'posts_per_page' => 10
         ]);
 
-        // スキーマクラスは OpenAPI 定義のみに使用
-        // データは Post オブジェクトの配列として返す
-        return array_map(fn($post) => new Post($post), $posts);
+        return array_map(fn($post) => new Post(
+            ID: $post->ID,
+            post_author: $post->post_author,
+            post_date: $post->post_date,
+            post_date_gmt: $post->post_date_gmt,
+            post_content: $post->post_content,
+            post_title: $post->post_title,
+            post_status: $post->post_status,
+            post_name: $post->post_name,
+        ), $posts);
     }
 }

--- a/src/REST/Example/Schemas/Post.php
+++ b/src/REST/Example/Schemas/Post.php
@@ -2,20 +2,22 @@
 namespace Wp\Resta\REST\Example\Schemas;
 
 use Wp\Resta\REST\Schemas\ObjectType;
-use WP_Post;
 
 class Post extends ObjectType
 {
     public const ID = '#/components/schemas/Post';
 
-    public readonly int $ID;
-    public readonly string $post_author;
-    public readonly string $post_date;
-    public readonly string $post_date_gmt;
-    public readonly string $post_content;
-    public readonly string $post_title;
-    public readonly string $post_status;
-    public readonly string $post_name;
+    public function __construct(
+        public int $ID,
+        public string $post_author,
+        public string $post_date,
+        public string $post_date_gmt,
+        public string $post_content,
+        public string $post_title,
+        public string $post_status,
+        public string $post_name,
+    ) {
+    }
 
     public static function metadata(): array
     {
@@ -29,17 +31,5 @@ class Post extends ObjectType
             'post_status' => ['description' => 'wp post status', 'example' => 'publish'],
             'post_name' => ['description' => 'wp post slug', 'example' => '1'],
         ];
-    }
-
-    public function __construct(WP_Post $post)
-    {
-        $this->ID = $post->ID;
-        $this->post_author = $post->post_author;
-        $this->post_date = $post->post_date;
-        $this->post_date_gmt = $post->post_date_gmt;
-        $this->post_content = $post->post_content;
-        $this->post_title = $post->post_title;
-        $this->post_status = $post->post_status;
-        $this->post_name = $post->post_name;
     }
 }

--- a/src/REST/Example/Schemas/Post.php
+++ b/src/REST/Example/Schemas/Post.php
@@ -1,7 +1,6 @@
 <?php
 namespace Wp\Resta\REST\Example\Schemas;
 
-use Wp\Resta\REST\Attributes\Schema\Property;
 use Wp\Resta\REST\Schemas\ObjectType;
 use WP_Post;
 
@@ -9,29 +8,28 @@ class Post extends ObjectType
 {
     public const ID = '#/components/schemas/Post';
 
-    #[Property(['type' => 'integer', 'description'=>'wp post id', 'example' => 1])]
     public readonly int $ID;
-
-    #[Property(['type' => 'string', 'description'=>'wp post author', 'example' => '4'])]
     public readonly string $post_author;
-
-    #[Property(['type' => 'string', 'description'=>'wp post datetime', 'example' => '2024-05-19 21:58:47'])]
     public readonly string $post_date;
-
-    #[Property(['type' => 'string', 'description'=>'wp post datetime(gmt)', 'example' => '2024-05-19 12:58:47'])]
     public readonly string $post_date_gmt;
-
-    #[Property(['type' => 'string', 'description'=>'wp post content', 'example' => '<h1>Hello</h1><p>This is content</p>'])]
     public readonly string $post_content;
-
-    #[Property(['type' => 'string', 'description'=>'wp post title', 'example' => 'Hello'])]
     public readonly string $post_title;
-
-    #[Property(['type' => 'string', 'description'=>'wp post status', 'example' => 'publish'])]
     public readonly string $post_status;
-
-    #[Property(['type' => 'string', 'description'=>'wp post slug', 'example' => '1'])]
     public readonly string $post_name;
+
+    public static function metadata(): array
+    {
+        return [
+            'ID' => ['description' => 'wp post id', 'example' => 1],
+            'post_author' => ['description' => 'wp post author', 'example' => '4'],
+            'post_date' => ['description' => 'wp post datetime', 'example' => '2024-05-19 21:58:47'],
+            'post_date_gmt' => ['description' => 'wp post datetime(gmt)', 'example' => '2024-05-19 12:58:47'],
+            'post_content' => ['description' => 'wp post content', 'example' => '<h1>Hello</h1><p>This is content</p>'],
+            'post_title' => ['description' => 'wp post title', 'example' => 'Hello'],
+            'post_status' => ['description' => 'wp post status', 'example' => 'publish'],
+            'post_name' => ['description' => 'wp post slug', 'example' => '1'],
+        ];
+    }
 
     public function __construct(WP_Post $post)
     {

--- a/src/REST/Schemas/ArrayType.php
+++ b/src/REST/Schemas/ArrayType.php
@@ -1,14 +1,10 @@
 <?php
 namespace Wp\Resta\REST\Schemas;
 
-use ReflectionClass;
 use Wp\Resta\REST\Attributes\Schema\Property;
 
-abstract class ArrayType implements SchemaInterface
+abstract class ArrayType extends BaseSchema
 {
-    public const ID = null;
-    public const DESCRIPTION = null;
-
     public static function describe(): array
     {
         $description = [
@@ -16,16 +12,14 @@ abstract class ArrayType implements SchemaInterface
             'description' => static::DESCRIPTION ?: '',
             'items' => [],
         ];
-        $reflection = new ReflectionClass(static::class);
+        $reflection = self::getReflection();
         foreach ($reflection->getProperties() as $reflectionProperty) {
             $attributes = $reflectionProperty->getAttributes(Property::class);
             if ($reflectionProperty->name === 'items' && count($attributes) > 0) {
                 $description['items'] = $attributes[0]->newInstance()->toArray();
             }
         }
-        if (static::ID) {
-            $description['$id'] = static::ID;
-        }
+        $description['$id'] = self::getSchemaId();
         return $description;
     }
 }

--- a/src/REST/Schemas/BaseSchema.php
+++ b/src/REST/Schemas/BaseSchema.php
@@ -1,0 +1,40 @@
+<?php
+namespace Wp\Resta\REST\Schemas;
+
+use ReflectionClass;
+
+abstract class BaseSchema implements SchemaInterface
+{
+    /**
+     * @return ReflectionClass<static>
+     */
+    protected static function getReflection(): ReflectionClass
+    {
+        static $cache = [];
+        $class = static::class;
+        if (!isset($cache[$class])) {
+            $cache[$class] = new ReflectionClass($class);
+        }
+        return $cache[$class];
+    }
+
+    /**
+     * ID の生成：static::ID があればそれを使い、なければクラス名から自動生成
+     */
+    public static function getSchemaId(): string
+    {
+        $className = self::getReflection()->getShortName();
+        return static::ID ?: "#/components/schemas/{$className}";
+    }
+
+    /**
+     * オプション：プロパティのメタデータを定義
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function metadata(): array
+    {
+        return [];
+    }
+
+}

--- a/src/REST/Schemas/ObjectType.php
+++ b/src/REST/Schemas/ObjectType.php
@@ -6,26 +6,13 @@ use ReflectionNamedType;
 use ReflectionType;
 use Wp\Resta\REST\Attributes\Schema\Property;
 
-abstract class ObjectType implements SchemaInterface
+abstract class ObjectType extends BaseSchema
 {
-    public const ID = null;
-    public const DESCRIPTION = null;
-
-    /**
-     * オプション：プロパティのメタデータを定義
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    public static function metadata(): array
-    {
-        return [];
-    }
-
     public static function describe(): array
     {
         $properties = [];
         $required = [];
-        $reflection = new ReflectionClass(static::class);
+        $reflection = self::getReflection();
 
         // メタデータを取得（オプション）
         $metadata = static::metadata();
@@ -72,9 +59,7 @@ abstract class ObjectType implements SchemaInterface
             $description['required'] = $required;
         }
 
-        // ID の生成：static::ID があればそれを使い、なければクラス名から自動生成
-        $className = $reflection->getShortName();
-        $description['$id'] = static::ID ?: "#/components/schemas/{$className}";
+        $description['$id'] = self::getSchemaId();
 
         return $description;
     }

--- a/src/REST/Schemas/ObjectType.php
+++ b/src/REST/Schemas/ObjectType.php
@@ -2,6 +2,8 @@
 namespace Wp\Resta\REST\Schemas;
 
 use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionType;
 use Wp\Resta\REST\Attributes\Schema\Property;
 
 abstract class ObjectType implements SchemaInterface
@@ -9,15 +11,54 @@ abstract class ObjectType implements SchemaInterface
     public const ID = null;
     public const DESCRIPTION = null;
 
-    public static function describe() : array
+    /**
+     * オプション：プロパティのメタデータを定義
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function metadata(): array
+    {
+        return [];
+    }
+
+    public static function describe(): array
     {
         $properties = [];
+        $required = [];
         $reflection = new ReflectionClass(static::class);
+
+        // メタデータを取得（オプション）
+        $metadata = static::metadata();
+
         foreach ($reflection->getProperties() as $reflectionProperty) {
+            if ($reflectionProperty->isStatic()) {
+                continue;
+            }
+
+            $name = $reflectionProperty->name;
+
+            // 1. #[Property] Attribute がある場合（後方互換性）
             $attributes = $reflectionProperty->getAttributes(Property::class);
             if (count($attributes) > 0) {
                 $prop = $attributes[0]->newInstance();
-                $properties[$reflectionProperty->name] = $prop->toArray();
+                $properties[$name] = $prop->toArray();
+                continue;
+            }
+
+            // 2. プロパティの型から自動推論
+            $type = $reflectionProperty->getType();
+            $propSchema = self::typeToSchema($type);
+
+            // 3. metadata() から追加情報を取得
+            if (isset($metadata[$name])) {
+                $propSchema = array_merge($propSchema, $metadata[$name]);
+            }
+
+            $properties[$name] = $propSchema;
+
+            // nullable でなければ required
+            if ($type && !$type->allowsNull()) {
+                $required[] = $name;
             }
         }
 
@@ -26,10 +67,43 @@ abstract class ObjectType implements SchemaInterface
             'description' => static::DESCRIPTION ?: '',
             'properties' => $properties,
         ];
-        if (static::ID) {
-            $description['$id'] = static::ID;
+
+        if (!empty($required)) {
+            $description['required'] = $required;
         }
 
+        // ID の生成：static::ID があればそれを使い、なければクラス名から自動生成
+        $className = $reflection->getShortName();
+        $description['$id'] = static::ID ?: "#/components/schemas/{$className}";
+
         return $description;
+    }
+
+    /**
+     * ReflectionType から OpenAPI スキーマの型に変換
+     *
+     * @param ReflectionType|null $type
+     * @return array<string, mixed>
+     */
+    private static function typeToSchema(?ReflectionType $type): array
+    {
+        if (!$type) {
+            return ['type' => 'string'];
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            $typeName = $type->getName();
+
+            return match ($typeName) {
+                'int' => ['type' => 'integer'],
+                'float' => ['type' => 'number'],
+                'string' => ['type' => 'string'],
+                'bool' => ['type' => 'boolean'],
+                'array' => ['type' => 'array', 'items' => []],
+                default => ['$ref' => '#/components/schemas/' . basename(str_replace('\\', '/', $typeName))],
+            };
+        }
+
+        return ['type' => 'string'];
     }
 }

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -311,17 +311,27 @@ class SchemaInference
      */
     private function parseUseStatements(ReflectionClass $class): array
     {
+        static $cache = [];
         $fileName = $class->getFileName();
         if ($fileName === false) {
             return [];
+        }
+
+        // 一度解析したファイルはメモリキャッシュから再利用
+        if (isset($cache[$fileName])) {
+            /** @var array<string, string> */
+            return $cache[$fileName];
         }
 
         $content = file_get_contents($fileName);
         if ($content === false) {
             return [];
         }
+        if (!array_key_exists($fileName, $cache)) {
+            $cache[$fileName] = [];
+        }
 
-        $useStatements = [];
+        $useStatements =& $cache[$fileName];
 
         // 基本的な use 文を抽出: use Foo\Bar\Baz;
         preg_match_all(

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -40,9 +40,9 @@ class SchemaInference
      *
      * 優先順位：
      * 1. getSchema() メソッド（明示的定義）
-     * 2. callback の戻り値の型（DTO クラス）
-     * 3. callback の PHPDoc @return アノテーション（配列型）
-     * 4. フォールバック（推論不可 → null）
+     * 2. callback の戻り値の型（DTO クラス / プリミティブ型 / array など）
+     * 3. callback の PHPDoc @return アノテーション（配列型・array shape など）
+     * 4. 上記いずれからもスキーマを決定できない場合のみ null（プリミティブ型 / array の戻り値型は type 情報としてフォールバック推論される）
      *
      * @param RouteInterface $route
      * @return array<string, mixed>|null

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -68,7 +68,7 @@ class SchemaInference
 
                 // BaseSchema を継承するスキーマはIDつきなので $ref のみ
                 if (is_subclass_of($typeName, BaseSchema::class)) {
-                    $schemaId = $this->getSchemaId($typeName);
+                    $schemaId = $typeName::getSchemaId();
                     return ['$ref' => $schemaId];
                 }
             } elseif ($returnType->getName() === 'array') {
@@ -173,7 +173,7 @@ class SchemaInference
             $className = $this->resolveClassName($elementType->name, $context);
             if ($className && is_subclass_of($className, ObjectType::class)) {
                 // $ref を使用（スキーマの再利用）
-                $schemaId = $this->getSchemaId($className);
+                $schemaId = $className::getSchemaId();
                 return [
                     'type' => 'array',
                     'items' => [
@@ -223,7 +223,7 @@ class SchemaInference
                 $className = $this->resolveClassName($elementType->name, $context);
                 if ($className && is_subclass_of($className, ObjectType::class)) {
                     // $ref を使用（スキーマの再利用）
-                    $schemaId = $this->getSchemaId($className);
+                    $schemaId = $className::getSchemaId();
                     return [
                         'type' => 'array',
                         'items' => [
@@ -254,7 +254,7 @@ class SchemaInference
                 $className = $this->resolveClassName($valueType->name, $context);
                 if ($className && is_subclass_of($className, ObjectType::class)) {
                     // $ref を使用（スキーマの再利用）
-                    $schemaId = $this->getSchemaId($className);
+                    $schemaId = $className::getSchemaId();
                     return [
                         'type' => 'array',
                         'items' => [
@@ -284,24 +284,6 @@ class SchemaInference
             'null' => 'null',
             default => null,
         };
-    }
-
-    /**
-     * ObjectType クラスからスキーマIDを取得
-     *
-     * @param class-string<SchemaInterface> $className ObjectType のサブクラス
-     * @return string スキーマID（$ref用）
-     */
-    private function getSchemaId(string $className): string
-    {
-        // ObjectType::ID 定数があればそれを使用
-        if (defined("{$className}::ID") && $className::ID !== null) {
-            return $className::ID;
-        }
-
-        // なければクラス名から自動生成
-        $shortName = basename(str_replace('\\', '/', $className));
-        return "#/components/schemas/{$shortName}";
     }
 
     /**

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -15,7 +15,7 @@ class SchemaInference
      * Route からスキーマを推論
      *
      * 優先順位：
-     * 1. SCHEMA 定数（明示的定義）
+     * 1. getSchema() メソッド（明示的定義）
      * 2. callback の戻り値の型（DTO クラス）
      * 3. フォールバック（推論不可 → null）
      *
@@ -24,9 +24,10 @@ class SchemaInference
      */
     public function inferSchema(RouteInterface $route): ?array
     {
-        // 1. SCHEMA 定数が定義されていれば、それを使う（最優先・後方互換性）
-        if ($route::SCHEMA !== null) {
-            return $route::SCHEMA;
+        // 1. getSchema() が定義されていれば、それを使う（最優先・後方互換性）
+        $schema = $route->getSchema();
+        if ($schema !== null) {
+            return $schema;
         }
 
         // callback メソッドが存在するかチェック

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -1,7 +1,6 @@
 <?php
 namespace Wp\Resta\REST\Schemas;
 
-use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -1,0 +1,80 @@
+<?php
+namespace Wp\Resta\REST\Schemas;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Wp\Resta\REST\RouteInterface;
+
+/**
+ * Route の callback メソッドからスキーマを自動推論
+ */
+class SchemaInference
+{
+    /**
+     * Route からスキーマを推論
+     *
+     * 優先順位：
+     * 1. SCHEMA 定数（明示的定義）
+     * 2. callback の戻り値の型（DTO クラス）
+     * 3. フォールバック（推論不可 → null）
+     *
+     * @param RouteInterface $route
+     * @return array<string, mixed>|null
+     */
+    public function inferSchema(RouteInterface $route): ?array
+    {
+        // 1. SCHEMA 定数が定義されていれば、それを使う（最優先・後方互換性）
+        if ($route::SCHEMA !== null) {
+            return $route::SCHEMA;
+        }
+
+        // callback メソッドが存在するかチェック
+        if (!method_exists($route, 'callback')) {
+            return null;
+        }
+
+        $callback = new ReflectionMethod($route, 'callback');
+
+        // 2. 戻り値の型が DTO クラスか？
+        $returnType = $callback->getReturnType();
+        if ($returnType && $returnType instanceof ReflectionNamedType && !$returnType->isBuiltin()) {
+            $typeName = $returnType->getName();
+
+            // ObjectType を継承しているかチェック
+            if (is_subclass_of($typeName, ObjectType::class)) {
+                return $this->inferFromObjectType($typeName);
+            }
+
+            // ArrayType を継承しているかチェック
+            if (is_subclass_of($typeName, ArrayType::class)) {
+                return $this->inferFromArrayType($typeName);
+            }
+        }
+
+        // 3. フォールバック：推論できない
+        return null;
+    }
+
+    /**
+     * ObjectType クラスからスキーマを推論
+     *
+     * @param class-string $className
+     * @return array<string, mixed>
+     */
+    private function inferFromObjectType(string $className): array
+    {
+        return $className::describe();
+    }
+
+    /**
+     * ArrayType クラスからスキーマを推論
+     *
+     * @param class-string $className
+     * @return array<string, mixed>
+     */
+    private function inferFromArrayType(string $className): array
+    {
+        return $className::describe();
+    }
+}

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -344,14 +344,20 @@ class SchemaInference
         $useStatements =& $cache[$fileName];
 
         // 基本的な use 文を抽出: use Foo\Bar\Baz;
+        // as や { を含む行は後続の専用パターンで処理するため除外
         preg_match_all(
-            '/^\s*use\s+([^\s;]+)\s*;/m',
+            '/^\s*use\s+([^\s;{]+)\s*;/m',
             $content,
             $matches,
             PREG_SET_ORDER
         );
 
         foreach ($matches as $match) {
+            // as を含む行をスキップ（エイリアス付き use 文は別途処理）
+            if (strpos($match[0], ' as ') !== false) {
+                continue;
+            }
+
             $fqcn = $match[1];
             $parts = explode('\\', $fqcn);
             $alias = end($parts);

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -74,10 +74,7 @@ class SchemaInference
                 }
             } elseif ($returnType->getName() === 'array') {
                 // 3. 戻り値が array の場合、PHPDoc から要素型を推論
-                $schema = $this->inferFromPhpDoc();
-                if ($schema !== null) {
-                    return $schema;
-                }
+                return $this->inferFromPhpDoc();
             } else {
                 // 4. プリミティブ型（string, int, bool, float など）
                 $primitiveType = $this->mapPrimitiveType($returnType->getName());

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -170,9 +170,13 @@ class SchemaInference
             $className = $this->resolveClassName($elementType->name, $context);
 
             if ($className && is_subclass_of($className, ObjectType::class)) {
+                // $ref を使用（スキーマの再利用）
+                $schemaId = $this->getSchemaId($className);
                 return [
                     'type' => 'array',
-                    'items' => $className::describe(),
+                    'items' => [
+                        '$ref' => $schemaId,
+                    ],
                 ];
             }
         }
@@ -205,9 +209,13 @@ class SchemaInference
                 $className = $this->resolveClassName($elementType->name, $context);
 
                 if ($className && is_subclass_of($className, ObjectType::class)) {
+                    // $ref を使用（スキーマの再利用）
+                    $schemaId = $this->getSchemaId($className);
                     return [
                         'type' => 'array',
-                        'items' => $className::describe(),
+                        'items' => [
+                            '$ref' => $schemaId,
+                        ],
                     ];
                 }
             }
@@ -221,15 +229,37 @@ class SchemaInference
                 $className = $this->resolveClassName($valueType->name, $context);
 
                 if ($className && is_subclass_of($className, ObjectType::class)) {
+                    // $ref を使用（スキーマの再利用）
+                    $schemaId = $this->getSchemaId($className);
                     return [
                         'type' => 'array',
-                        'items' => $className::describe(),
+                        'items' => [
+                            '$ref' => $schemaId,
+                        ],
                     ];
                 }
             }
         }
 
         return null;
+    }
+
+    /**
+     * ObjectType クラスからスキーマIDを取得
+     *
+     * @param class-string $className ObjectType のサブクラス
+     * @return string スキーマID（$ref用）
+     */
+    private function getSchemaId(string $className): string
+    {
+        // ObjectType::ID 定数があればそれを使用
+        if (defined("{$className}::ID") && $className::ID !== null) {
+            return $className::ID;
+        }
+
+        // なければクラス名から自動生成
+        $shortName = basename(str_replace('\\', '/', $className));
+        return "#/components/schemas/{$shortName}";
     }
 
     /**

--- a/src/REST/Schemas/SchemaInference.php
+++ b/src/REST/Schemas/SchemaInference.php
@@ -66,14 +66,10 @@ class SchemaInference
             if (!$returnType->isBuiltin()) {
                 $typeName = $returnType->getName();
 
-                // ObjectType を継承しているかチェック
-                if (is_subclass_of($typeName, ObjectType::class)) {
-                    return $this->inferFromObjectType($typeName);
-                }
-
-                // ArrayType を継承しているかチェック
-                if (is_subclass_of($typeName, ArrayType::class)) {
-                    return $this->inferFromArrayType($typeName);
+                // BaseSchema を継承するスキーマはIDつきなので $ref のみ
+                if (is_subclass_of($typeName, BaseSchema::class)) {
+                    $schemaId = $this->getSchemaId($typeName);
+                    return ['$ref' => $schemaId];
                 }
             } elseif ($returnType->getName() === 'array') {
                 // 3. 戻り値が array の場合、PHPDoc から要素型を推論
@@ -104,28 +100,6 @@ class SchemaInference
 
         // 5. フォールバック：推論できない
         return null;
-    }
-
-    /**
-     * ObjectType クラスからスキーマを推論
-     *
-     * @param class-string $className
-     * @return array<string, mixed>
-     */
-    private function inferFromObjectType(string $className): array
-    {
-        return $className::describe();
-    }
-
-    /**
-     * ArrayType クラスからスキーマを推論
-     *
-     * @param class-string $className
-     * @return array<string, mixed>
-     */
-    private function inferFromArrayType(string $className): array
-    {
-        return $className::describe();
     }
 
     /**
@@ -315,7 +289,7 @@ class SchemaInference
     /**
      * ObjectType クラスからスキーマIDを取得
      *
-     * @param class-string $className ObjectType のサブクラス
+     * @param class-string<SchemaInterface> $className ObjectType のサブクラス
      * @return string スキーマID（$ref用）
      */
     private function getSchemaId(string $className): string

--- a/src/REST/Schemas/SchemaInterface.php
+++ b/src/REST/Schemas/SchemaInterface.php
@@ -3,8 +3,11 @@ namespace Wp\Resta\REST\Schemas;
 
 interface SchemaInterface
 {
+    public const ID = null;
+    public const DESCRIPTION = null;
     /**
      * @return array<string, mixed>
      */
     public static function describe(): array;
+    public static function getSchemaId(): string;
 }

--- a/tests/E2E/Api/ExampleApiTest.php
+++ b/tests/E2E/Api/ExampleApiTest.php
@@ -105,10 +105,10 @@ class ExampleApiTest extends AbstractE2ETestCase
 
         $data = $this->getJsonResponse($response);
 
+        // Envelope構造で、dataが直接Post型を含む
         $this->assertArrayHasKey('data', $data);
-        $this->assertArrayHasKey('post', $data['data']);
-        $this->assertArrayHasKey('ID', $data['data']['post']);
-        $this->assertEquals(1, $data['data']['post']['ID']);
+        $this->assertArrayHasKey('ID', $data['data']);
+        $this->assertEquals(1, $data['data']['ID']);
     }
 
     public function testPostApiWithNonExistentId(): void

--- a/tests/E2E/Api/ParameterPriorityTest.php
+++ b/tests/E2E/Api/ParameterPriorityTest.php
@@ -136,9 +136,9 @@ class ParameterPriorityTest extends AbstractE2ETestCase
 
         $data = $this->getJsonResponse($response);
 
-        // URLパラメータ (1) が優先される (envelope構造)
+        // URLパラメータ (1) が優先される (envelope構造で、dataが直接Post型を含む)
         $this->assertArrayHasKey('data', $data);
-        $this->assertArrayHasKey('post', $data['data']);
-        $this->assertEquals(1, $data['data']['post']['ID']);
+        $this->assertArrayHasKey('ID', $data['data']);
+        $this->assertEquals(1, $data['data']['ID']);
     }
 }

--- a/tests/Fixtures/Routes/TestAssociativePrimitiveRoute.php
+++ b/tests/Fixtures/Routes/TestAssociativePrimitiveRoute.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for associative primitive array type inference
+ */
+class TestAssociativePrimitiveRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-associative-primitive';
+
+    /**
+     * @return array<int, string>
+     */
+    public function callback(): array
+    {
+        return ['foo', 'bar', 'baz'];
+    }
+}

--- a/tests/Fixtures/Routes/TestBoolReturnRoute.php
+++ b/tests/Fixtures/Routes/TestBoolReturnRoute.php
@@ -1,0 +1,17 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for bool return type inference
+ */
+class TestBoolReturnRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-bool-return';
+
+    public function callback(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Routes/TestGenericPrimitiveRoute.php
+++ b/tests/Fixtures/Routes/TestGenericPrimitiveRoute.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for generic primitive array type inference
+ */
+class TestGenericPrimitiveRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-generic-primitive';
+
+    /**
+     * @return array<string>
+     */
+    public function callback(): array
+    {
+        return ['foo', 'bar', 'baz'];
+    }
+}

--- a/tests/Fixtures/Routes/TestInferredSchemaRoute.php
+++ b/tests/Fixtures/Routes/TestInferredSchemaRoute.php
@@ -1,0 +1,22 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+use Test\Resta\Fixtures\Schemas\TestUser;
+
+/**
+ * SCHEMA 定数を持たず、callback の戻り値から自動推論されるRoute
+ */
+class TestInferredSchemaRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-inferred';
+
+    public function callback(): TestUser
+    {
+        $user = new TestUser();
+        $user->id = 1;
+        $user->name = 'Test User';
+        $user->email = 'test@example.com';
+        return $user;
+    }
+}

--- a/tests/Fixtures/Routes/TestIntReturnRoute.php
+++ b/tests/Fixtures/Routes/TestIntReturnRoute.php
@@ -1,0 +1,17 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for int return type inference
+ */
+class TestIntReturnRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-int-return';
+
+    public function callback(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/Routes/TestIntegerArrayRoute.php
+++ b/tests/Fixtures/Routes/TestIntegerArrayRoute.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for integer array type inference
+ */
+class TestIntegerArrayRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-integer-array';
+
+    /**
+     * @return int[]
+     */
+    public function callback(): array
+    {
+        return [1, 2, 3];
+    }
+}

--- a/tests/Fixtures/Routes/TestNullableStringReturnRoute.php
+++ b/tests/Fixtures/Routes/TestNullableStringReturnRoute.php
@@ -1,0 +1,17 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for nullable string return type inference
+ */
+class TestNullableStringReturnRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-nullable-string-return';
+
+    public function callback(): ?string
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Routes/TestPhpDocArrayRoute.php
+++ b/tests/Fixtures/Routes/TestPhpDocArrayRoute.php
@@ -1,0 +1,21 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+use Test\Resta\Fixtures\Schemas\TestUser;
+
+/**
+ * PHPDoc の @return アノテーションでスキーマを定義するRoute
+ */
+class TestPhpDocArrayRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-phpdoc-array';
+
+    /**
+     * @return TestUser[]
+     */
+    public function callback(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Routes/TestPhpDocAssociativeRoute.php
+++ b/tests/Fixtures/Routes/TestPhpDocAssociativeRoute.php
@@ -1,0 +1,21 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+use Test\Resta\Fixtures\Schemas\TestUser;
+
+/**
+ * PHPDoc の array<string, Type> 形式をテスト
+ */
+class TestPhpDocAssociativeRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-phpdoc-associative';
+
+    /**
+     * @return array<string, TestUser>
+     */
+    public function callback(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Routes/TestPhpDocGenericRoute.php
+++ b/tests/Fixtures/Routes/TestPhpDocGenericRoute.php
@@ -1,0 +1,21 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+use Test\Resta\Fixtures\Schemas\TestUser;
+
+/**
+ * PHPDoc の array<Type> 形式をテスト
+ */
+class TestPhpDocGenericRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-phpdoc-generic';
+
+    /**
+     * @return array<TestUser>
+     */
+    public function callback(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Routes/TestPrimitiveArrayRoute.php
+++ b/tests/Fixtures/Routes/TestPrimitiveArrayRoute.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for primitive array type inference
+ */
+class TestPrimitiveArrayRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-primitive-array';
+
+    /**
+     * @return string[]
+     */
+    public function callback(): array
+    {
+        return ['foo', 'bar', 'baz'];
+    }
+}

--- a/tests/Fixtures/Routes/TestStringReturnRoute.php
+++ b/tests/Fixtures/Routes/TestStringReturnRoute.php
@@ -1,0 +1,17 @@
+<?php
+namespace Test\Resta\Fixtures\Routes;
+
+use Wp\Resta\REST\AbstractRoute;
+
+/**
+ * Test Route for string return type inference
+ */
+class TestStringReturnRoute extends AbstractRoute
+{
+    protected const ROUTE = 'test-string-return';
+
+    public function callback(): string
+    {
+        return 'Hello, World!';
+    }
+}

--- a/tests/Fixtures/Schemas/TestUser.php
+++ b/tests/Fixtures/Schemas/TestUser.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Resta\Fixtures\Schemas;
+
+use Wp\Resta\REST\Schemas\ObjectType;
+
+class TestUser extends ObjectType
+{
+    public int $id;
+    public string $name;
+    public string $email;
+
+    public static function metadata(): array
+    {
+        return [
+            'id' => ['description' => 'User ID', 'example' => 1],
+            'name' => ['description' => 'User name', 'example' => 'John Doe'],
+            'email' => ['description' => 'User email', 'example' => 'john@example.com'],
+        ];
+    }
+}

--- a/tests/Integration/OpenApi/ResponseSchemaTest.php
+++ b/tests/Integration/OpenApi/ResponseSchemaTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Test\Resta\Integration\OpenApi;
+
+use PHPUnit\Framework\TestCase;
+use Wp\Resta\Config;
+use Wp\Resta\DI\Container;
+use Wp\Resta\OpenApi\ResponseSchema;
+use ReflectionClass;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+class ResponseSchemaTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        // WordPressの関数をモック
+        Functions\when('rest_url')->justReturn('http://localhost/wp-json/');
+
+        // Containerをリセット
+        $this->container = Container::getInstance();
+        $reflection = new ReflectionClass(Container::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+        $this->container = Container::getInstance();
+
+        // Configをセットアップ
+        $config = new Config([
+            'routeDirectory' => [
+                [__DIR__ . '/../../Fixtures/Routes', 'Test\\Resta\\Fixtures\\Routes\\', 'test'],
+            ],
+        ]);
+
+        $this->container->bind(Config::class, $config);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+
+        // Containerをリセット
+        $reflection = new ReflectionClass(Container::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    public function testSchemaInferenceIntegration()
+    {
+        // DIコンテナから全て取得
+        $responseSchema = $this->container->get(ResponseSchema::class);
+
+        $result = $responseSchema->responseSchema();
+
+        $this->assertArrayHasKey('openapi', $result);
+        $this->assertArrayHasKey('paths', $result);
+        $this->assertArrayHasKey('components', $result);
+
+        // TestInferredSchemaRoute のスキーマが自動推論されているか確認
+        $testPath = '/test/test-inferred';
+        $this->assertArrayHasKey($testPath, $result['paths']);
+
+        $schema = $result['paths'][$testPath]['get']['responses']['200']['content']['application/json']['schema'];
+
+        // スキーマの構造を確認
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('id', $schema['properties']);
+        $this->assertArrayHasKey('name', $schema['properties']);
+        $this->assertArrayHasKey('email', $schema['properties']);
+
+        // metadata() からの情報も含まれているか確認
+        $this->assertEquals('integer', $schema['properties']['id']['type']);
+        $this->assertEquals('User ID', $schema['properties']['id']['description']);
+
+        $this->assertEquals('string', $schema['properties']['name']['type']);
+        $this->assertEquals('User name', $schema['properties']['name']['description']);
+
+        $this->assertEquals('string', $schema['properties']['email']['type']);
+        $this->assertEquals('User email', $schema['properties']['email']['description']);
+    }
+
+    public function testRouteWithoutSchemaHasEmptySchema()
+    {
+        $responseSchema = $this->container->get(ResponseSchema::class);
+        $result = $responseSchema->responseSchema();
+
+        // TestRoute は SCHEMA 定数もなく、callback が string を返すだけなので、スキーマは空
+        $testPath = '/test/test';
+        $this->assertArrayHasKey($testPath, $result['paths']);
+
+        $schema = $result['paths'][$testPath]['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertEmpty($schema);
+    }
+}

--- a/tests/Integration/OpenApi/ResponseSchemaTest.php
+++ b/tests/Integration/OpenApi/ResponseSchemaTest.php
@@ -87,16 +87,17 @@ class ResponseSchemaTest extends TestCase
         $this->assertEquals('User email', $schema['properties']['email']['description']);
     }
 
-    public function testRouteWithoutSchemaHasEmptySchema()
+    public function testRouteWithBuiltinReturnTypeInfersSchema()
     {
         $responseSchema = $this->container->get(ResponseSchema::class);
         $result = $responseSchema->responseSchema();
 
-        // TestRoute は SCHEMA 定数もなく、callback が string を返すだけなので、スキーマは空
+        // TestRoute は SCHEMA 定数がないが、callback(): string から自動推論される
         $testPath = '/test/test';
         $this->assertArrayHasKey($testPath, $result['paths']);
 
         $schema = $result['paths'][$testPath]['get']['responses']['200']['content']['application/json']['schema'];
-        $this->assertEmpty($schema);
+        $this->assertArrayHasKey('type', $schema);
+        $this->assertEquals('string', $schema['type']);
     }
 }

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -54,18 +54,17 @@ class SchemaInferenceTest extends TestCase
 
     public function testInferSchemaFromObjectTypeReturnType()
     {
-        // ObjectType を返す場合
+        // ObjectType を返す場合、$ref で参照される
         $route = new TestUserRoute();
 
         $schema = $this->inference->inferSchema($route);
 
         $this->assertNotNull($schema);
-        $this->assertEquals('object', $schema['type']);
-        $this->assertArrayHasKey('properties', $schema);
-        $this->assertArrayHasKey('id', $schema['properties']);
-        $this->assertArrayHasKey('name', $schema['properties']);
-        $this->assertEquals('User ID', $schema['properties']['id']['description']);
-        $this->assertEquals('User name', $schema['properties']['name']['description']);
+        $this->assertArrayHasKey('$ref', $schema);
+        $this->assertStringContainsString('TestUserType', $schema['$ref']);
+        // type や properties は含まれない（$ref のみ）
+        $this->assertArrayNotHasKey('type', $schema);
+        $this->assertArrayNotHasKey('properties', $schema);
     }
 
     public function testInferSchemaReturnsNullWhenNoSchemaAvailable()

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -67,7 +67,7 @@ class SchemaInferenceTest extends TestCase
         $this->assertArrayNotHasKey('properties', $schema);
     }
 
-    public function testInferSchemaReturnsNullWhenNoSchemaAvailable()
+    public function testInferSchemaReturnsSimpleArrayTypeWhenNoSchemaAvailable()
     {
         // SCHEMA 定数もなく、戻り値の型も builtin の場合
         $route = new class extends AbstractRoute {
@@ -79,7 +79,7 @@ class SchemaInferenceTest extends TestCase
 
         $schema = $this->inference->inferSchema($route);
 
-        $this->assertEquals($schema, ['type' => 'array']);
+        $this->assertEquals(['type' => 'array'], $schema);
     }
 
     public function testInferSchemaReturnsNullWhenNoCallbackMethod()

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -79,7 +79,7 @@ class SchemaInferenceTest extends TestCase
 
         $schema = $this->inference->inferSchema($route);
 
-        $this->assertNull($schema);
+        $this->assertEquals($schema, ['type' => 'array']);
     }
 
     public function testInferSchemaReturnsNullWhenNoCallbackMethod()

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -5,6 +5,14 @@ use PHPUnit\Framework\TestCase;
 use Test\Resta\Fixtures\Routes\TestPhpDocArrayRoute;
 use Test\Resta\Fixtures\Routes\TestPhpDocAssociativeRoute;
 use Test\Resta\Fixtures\Routes\TestPhpDocGenericRoute;
+use Test\Resta\Fixtures\Routes\TestPrimitiveArrayRoute;
+use Test\Resta\Fixtures\Routes\TestIntegerArrayRoute;
+use Test\Resta\Fixtures\Routes\TestGenericPrimitiveRoute;
+use Test\Resta\Fixtures\Routes\TestAssociativePrimitiveRoute;
+use Test\Resta\Fixtures\Routes\TestStringReturnRoute;
+use Test\Resta\Fixtures\Routes\TestIntReturnRoute;
+use Test\Resta\Fixtures\Routes\TestBoolReturnRoute;
+use Test\Resta\Fixtures\Routes\TestNullableStringReturnRoute;
 use Wp\Resta\REST\AbstractRoute;
 use Wp\Resta\REST\Schemas\ObjectType;
 use Wp\Resta\REST\Schemas\SchemaInference;
@@ -156,6 +164,106 @@ class SchemaInferenceTest extends TestCase
         // $ref を使用することを確認
         $this->assertArrayHasKey('$ref', $schema['items']);
         $this->assertStringContainsString('TestUser', $schema['items']['$ref']);
+    }
+
+    public function testInferSchemaFromPhpDocPrimitiveArray()
+    {
+        // @return string[] 形式のPHPDocからスキーマを推論
+        $route = new TestPrimitiveArrayRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('string', $schema['items']['type']);
+        $this->assertArrayNotHasKey('$ref', $schema['items']);
+    }
+
+    public function testInferSchemaFromPhpDocIntegerArray()
+    {
+        // @return int[] 形式のPHPDocからスキーマを推論
+        $route = new TestIntegerArrayRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('integer', $schema['items']['type']);
+    }
+
+    public function testInferSchemaFromPhpDocGenericPrimitive()
+    {
+        // @return array<string> 形式のPHPDocからスキーマを推論
+        $route = new TestGenericPrimitiveRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('string', $schema['items']['type']);
+    }
+
+    public function testInferSchemaFromPhpDocAssociativePrimitive()
+    {
+        // @return array<int, string> 形式のPHPDocからスキーマを推論
+        $route = new TestAssociativePrimitiveRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('string', $schema['items']['type']);
+    }
+
+    public function testInferSchemaFromStringReturnType()
+    {
+        // callback(): string からスキーマを推論
+        $route = new TestStringReturnRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('string', $schema['type']);
+    }
+
+    public function testInferSchemaFromIntReturnType()
+    {
+        // callback(): int からスキーマを推論
+        $route = new TestIntReturnRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('integer', $schema['type']);
+    }
+
+    public function testInferSchemaFromBoolReturnType()
+    {
+        // callback(): bool からスキーマを推論
+        $route = new TestBoolReturnRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('boolean', $schema['type']);
+    }
+
+    public function testInferSchemaFromNullableStringReturnType()
+    {
+        // callback(): ?string からスキーマを推論
+        $route = new TestNullableStringReturnRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertArrayHasKey('anyOf', $schema);
+        $this->assertCount(2, $schema['anyOf']);
+        $this->assertEquals('string', $schema['anyOf'][0]['type']);
+        $this->assertEquals('null', $schema['anyOf'][1]['type']);
     }
 }
 

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -2,6 +2,9 @@
 namespace Test\Resta\Unit\REST\Schemas;
 
 use PHPUnit\Framework\TestCase;
+use Test\Resta\Fixtures\Routes\TestPhpDocArrayRoute;
+use Test\Resta\Fixtures\Routes\TestPhpDocAssociativeRoute;
+use Test\Resta\Fixtures\Routes\TestPhpDocGenericRoute;
 use Wp\Resta\REST\AbstractRoute;
 use Wp\Resta\REST\Schemas\ObjectType;
 use Wp\Resta\REST\Schemas\SchemaInference;
@@ -108,6 +111,49 @@ class SchemaInferenceTest extends TestCase
         $this->assertNotNull($schema);
         $this->assertArrayHasKey('fromConstant', $schema['properties']);
         $this->assertArrayNotHasKey('id', $schema['properties'] ?? []);
+    }
+
+    public function testInferSchemaFromPhpDocArrayAnnotation()
+    {
+        // @return TestUser[] 形式のPHPDocからスキーマを推論
+        $route = new TestPhpDocArrayRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('object', $schema['items']['type']);
+        $this->assertArrayHasKey('id', $schema['items']['properties']);
+        $this->assertArrayHasKey('name', $schema['items']['properties']);
+    }
+
+    public function testInferSchemaFromPhpDocGenericAnnotation()
+    {
+        // @return array<TestUser> 形式のPHPDocからスキーマを推論
+        $route = new TestPhpDocGenericRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('object', $schema['items']['type']);
+    }
+
+    public function testInferSchemaFromPhpDocAssociativeAnnotation()
+    {
+        // @return array<string, TestUser> 形式のPHPDocからスキーマを推論
+        $route = new TestPhpDocAssociativeRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('array', $schema['type']);
+        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('object', $schema['items']['type']);
+        $this->assertArrayHasKey('id', $schema['items']['properties']);
+        $this->assertArrayHasKey('name', $schema['items']['properties']);
     }
 }
 

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -1,0 +1,143 @@
+<?php
+namespace Test\Resta\Unit\REST\Schemas;
+
+use PHPUnit\Framework\TestCase;
+use Wp\Resta\REST\AbstractRoute;
+use Wp\Resta\REST\Schemas\ObjectType;
+use Wp\Resta\REST\Schemas\SchemaInference;
+
+class SchemaInferenceTest extends TestCase
+{
+    private SchemaInference $inference;
+
+    protected function setUp(): void
+    {
+        $this->inference = new SchemaInference();
+    }
+
+    public function testInferSchemaFromConstant()
+    {
+        // SCHEMA 定数が定義されている場合
+        $route = new class extends AbstractRoute {
+            public const SCHEMA = [
+                'type' => 'object',
+                'properties' => [
+                    'id' => ['type' => 'integer'],
+                    'name' => ['type' => 'string'],
+                ],
+            ];
+
+            public function callback(): array
+            {
+                return [];
+            }
+        };
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('id', $schema['properties']);
+        $this->assertArrayHasKey('name', $schema['properties']);
+    }
+
+    public function testInferSchemaFromObjectTypeReturnType()
+    {
+        // ObjectType を返す場合
+        $route = new TestUserRoute();
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('id', $schema['properties']);
+        $this->assertArrayHasKey('name', $schema['properties']);
+        $this->assertEquals('User ID', $schema['properties']['id']['description']);
+        $this->assertEquals('User name', $schema['properties']['name']['description']);
+    }
+
+    public function testInferSchemaReturnsNullWhenNoSchemaAvailable()
+    {
+        // SCHEMA 定数もなく、戻り値の型も builtin の場合
+        $route = new class extends AbstractRoute {
+            public function callback(): array
+            {
+                return [];
+            }
+        };
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNull($schema);
+    }
+
+    public function testInferSchemaReturnsNullWhenNoCallbackMethod()
+    {
+        // callback メソッドがない場合
+        $route = new class extends AbstractRoute {
+            // callback メソッドなし
+        };
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNull($schema);
+    }
+
+    public function testSchemaConstantHasPriorityOverReturnType()
+    {
+        // SCHEMA 定数と戻り値の型の両方がある場合、SCHEMA が優先される
+        $route = new class extends AbstractRoute {
+            public const SCHEMA = [
+                'type' => 'object',
+                'properties' => [
+                    'fromConstant' => ['type' => 'string'],
+                ],
+            ];
+
+            public function callback(): object
+            {
+                return new class extends ObjectType {
+                    public int $id;
+                };
+            }
+        };
+
+        $schema = $this->inference->inferSchema($route);
+
+        $this->assertNotNull($schema);
+        $this->assertArrayHasKey('fromConstant', $schema['properties']);
+        $this->assertArrayNotHasKey('id', $schema['properties'] ?? []);
+    }
+}
+
+// Test fixture classes
+
+/**
+ * Test ObjectType for SchemaInference tests
+ */
+class TestUserType extends ObjectType
+{
+    public int $id;
+    public string $name;
+
+    public static function metadata(): array
+    {
+        return [
+            'id' => ['description' => 'User ID'],
+            'name' => ['description' => 'User name'],
+        ];
+    }
+}
+
+/**
+ * Test Route that returns TestUserType
+ */
+class TestUserRoute extends AbstractRoute
+{
+    public function callback(): TestUserType
+    {
+        // このメソッドは実際には呼ばれない（Reflection で型情報を取得するだけ）
+        return new TestUserType();
+    }
+}

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -123,9 +123,9 @@ class SchemaInferenceTest extends TestCase
         $this->assertNotNull($schema);
         $this->assertEquals('array', $schema['type']);
         $this->assertArrayHasKey('items', $schema);
-        $this->assertEquals('object', $schema['items']['type']);
-        $this->assertArrayHasKey('id', $schema['items']['properties']);
-        $this->assertArrayHasKey('name', $schema['items']['properties']);
+        // $ref を使用することを確認
+        $this->assertArrayHasKey('$ref', $schema['items']);
+        $this->assertStringContainsString('TestUser', $schema['items']['$ref']);
     }
 
     public function testInferSchemaFromPhpDocGenericAnnotation()
@@ -138,7 +138,9 @@ class SchemaInferenceTest extends TestCase
         $this->assertNotNull($schema);
         $this->assertEquals('array', $schema['type']);
         $this->assertArrayHasKey('items', $schema);
-        $this->assertEquals('object', $schema['items']['type']);
+        // $ref を使用することを確認
+        $this->assertArrayHasKey('$ref', $schema['items']);
+        $this->assertStringContainsString('TestUser', $schema['items']['$ref']);
     }
 
     public function testInferSchemaFromPhpDocAssociativeAnnotation()
@@ -151,9 +153,9 @@ class SchemaInferenceTest extends TestCase
         $this->assertNotNull($schema);
         $this->assertEquals('array', $schema['type']);
         $this->assertArrayHasKey('items', $schema);
-        $this->assertEquals('object', $schema['items']['type']);
-        $this->assertArrayHasKey('id', $schema['items']['properties']);
-        $this->assertArrayHasKey('name', $schema['items']['properties']);
+        // $ref を使用することを確認
+        $this->assertArrayHasKey('$ref', $schema['items']);
+        $this->assertStringContainsString('TestUser', $schema['items']['$ref']);
     }
 }
 

--- a/tests/Unit/REST/Schemas/SchemaInferenceTest.php
+++ b/tests/Unit/REST/Schemas/SchemaInferenceTest.php
@@ -158,11 +158,11 @@ class SchemaInferenceTest extends TestCase
         $schema = $this->inference->inferSchema($route);
 
         $this->assertNotNull($schema);
-        $this->assertEquals('array', $schema['type']);
-        $this->assertArrayHasKey('items', $schema);
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('additionalProperties', $schema);
         // $ref を使用することを確認
-        $this->assertArrayHasKey('$ref', $schema['items']);
-        $this->assertStringContainsString('TestUser', $schema['items']['$ref']);
+        $this->assertArrayHasKey('$ref', $schema['additionalProperties']);
+        $this->assertStringContainsString('TestUser', $schema['additionalProperties']['$ref']);
     }
 
     public function testInferSchemaFromPhpDocPrimitiveArray()

--- a/tests/Unit/REST/Schemas/SchemaTest.php
+++ b/tests/Unit/REST/Schemas/SchemaTest.php
@@ -42,6 +42,15 @@ class SchemaTest extends TestCase
             public string $firstName;
         };
 
+        $described = $newType::describe();
+
+        // $id は自動生成されるので、存在することだけ確認
+        $this->assertArrayHasKey('$id', $described);
+        $this->assertStringStartsWith('#/components/schemas/', $described['$id']);
+
+        // $id 以外をチェック
+        unset($described['$id']);
+
         $this->assertEquals(
             [
                 'type' => 'object',
@@ -62,7 +71,163 @@ class SchemaTest extends TestCase
                 ],
                 'description' => 'This is anonymous object type',
             ],
-            $newType::describe()
+            $described
         );
+    }
+
+    public function testObjectTypeSchemaWithTypeInference()
+    {
+        $newType = new class() extends ObjectType {
+            public const DESCRIPTION = 'Test schema with type inference';
+
+            public int $id;
+            public string $name;
+            public ?string $description;
+            public bool $active;
+            public float $price;
+        };
+
+        $described = $newType::describe();
+
+        // $id の存在確認
+        $this->assertArrayHasKey('$id', $described);
+        $this->assertStringStartsWith('#/components/schemas/', $described['$id']);
+
+        // 基本的な構造
+        $this->assertEquals('object', $described['type']);
+        $this->assertEquals('Test schema with type inference', $described['description']);
+
+        // プロパティの型が正しく推論されているか
+        $this->assertEquals('integer', $described['properties']['id']['type']);
+        $this->assertEquals('string', $described['properties']['name']['type']);
+        $this->assertEquals('string', $described['properties']['description']['type']);
+        $this->assertEquals('boolean', $described['properties']['active']['type']);
+        $this->assertEquals('number', $described['properties']['price']['type']);
+
+        // nullable でないプロパティが required に含まれているか
+        $this->assertContains('id', $described['required']);
+        $this->assertContains('name', $described['required']);
+        $this->assertContains('active', $described['required']);
+        $this->assertContains('price', $described['required']);
+
+        // nullable なプロパティは required に含まれない
+        $this->assertNotContains('description', $described['required']);
+    }
+
+    public function testObjectTypeSchemaWithMetadata()
+    {
+        $newType = new class() extends ObjectType {
+            public int $id;
+            public string $name;
+            public ?string $email;
+
+            public static function metadata(): array
+            {
+                return [
+                    'id' => ['description' => 'User ID', 'example' => 123],
+                    'name' => ['description' => 'User name', 'example' => 'John Doe'],
+                    'email' => ['description' => 'User email', 'example' => 'john@example.com'],
+                ];
+            }
+        };
+
+        $described = $newType::describe();
+
+        // metadata() の内容がマージされているか
+        $this->assertEquals('User ID', $described['properties']['id']['description']);
+        $this->assertEquals(123, $described['properties']['id']['example']);
+
+        $this->assertEquals('User name', $described['properties']['name']['description']);
+        $this->assertEquals('John Doe', $described['properties']['name']['example']);
+
+        $this->assertEquals('User email', $described['properties']['email']['description']);
+        $this->assertEquals('john@example.com', $described['properties']['email']['example']);
+    }
+
+    public function testObjectTypeSchemaWithCustomId()
+    {
+        $newType = new class() extends ObjectType {
+            public const ID = '#/components/schemas/CustomUser';
+
+            public int $id;
+            public string $name;
+        };
+
+        $described = $newType::describe();
+
+        // カスタム ID が使われているか
+        $this->assertEquals('#/components/schemas/CustomUser', $described['$id']);
+    }
+
+    public function testObjectTypeSchemaWithClassReference()
+    {
+        // 参照先のクラスを定義
+        $authorType = new class() extends ObjectType {
+            public int $id;
+            public string $name;
+        };
+
+        // クラス参照を持つスキーマ
+        $postType = new class() extends ObjectType {
+            public int $id;
+            public string $title;
+            // 注: 実際のクラス参照は複雑なので、テストでは型の推論のみ確認
+        };
+
+        $described = $postType::describe();
+
+        $this->assertEquals('integer', $described['properties']['id']['type']);
+        $this->assertEquals('string', $described['properties']['title']['type']);
+    }
+
+    public function testObjectTypeSchemaBackwardCompatibility()
+    {
+        // Attribute と型推論の混在
+        $newType = new class() extends ObjectType {
+            #[Property(['type' => 'integer', 'description' => 'With attribute'])]
+            public int $id;
+
+            // Attribute なし（型推論）
+            public string $name;
+
+            public static function metadata(): array
+            {
+                return [
+                    'name' => ['description' => 'With metadata'],
+                ];
+            }
+        };
+
+        $described = $newType::describe();
+
+        // Attribute が優先される
+        $this->assertEquals('integer', $described['properties']['id']['type']);
+        $this->assertEquals('With attribute', $described['properties']['id']['description']);
+
+        // 型推論 + metadata
+        $this->assertEquals('string', $described['properties']['name']['type']);
+        $this->assertEquals('With metadata', $described['properties']['name']['description']);
+    }
+
+    public function testObjectTypeSchemaWithArrayType()
+    {
+        $newType = new class() extends ObjectType {
+            public int $id;
+            public array $tags;
+
+            public static function metadata(): array
+            {
+                return [
+                    'tags' => ['description' => 'Tag list', 'items' => ['type' => 'string']],
+                ];
+            }
+        };
+
+        $described = $newType::describe();
+
+        $this->assertEquals('array', $described['properties']['tags']['type']);
+        $this->assertEquals('Tag list', $described['properties']['tags']['description']);
+        // metadata から items が追加される
+        $this->assertArrayHasKey('items', $described['properties']['tags']);
     }
 }

--- a/tests/Unit/REST/Schemas/SchemaTest.php
+++ b/tests/Unit/REST/Schemas/SchemaTest.php
@@ -40,7 +40,7 @@ class SchemaTest extends TestCase
             #[Property(['type' => 'string', 'example' => 'amashige'])]
             public string $lastName;
 
-            #[Property(['type' => 'string', 'description' => 'first name is first name.', 'example' => 'seiji'])]
+            #[Property(['description' => 'first name is first name.', 'example' => 'seiji'])]
             public string $firstName;
         };
 
@@ -72,6 +72,7 @@ class SchemaTest extends TestCase
                     ],
                 ],
                 'description' => 'This is anonymous object type',
+                'required' => ['id', 'lastName', 'firstName'],
             ],
             $described
         );

--- a/tests/Unit/REST/Schemas/SchemaTest.php
+++ b/tests/Unit/REST/Schemas/SchemaTest.php
@@ -11,7 +11,7 @@ class SchemaTest extends TestCase
     public function testArrayTypeSchema()
     {
         $newType = new class() extends ArrayType {
-            public const ID = 'anonymosArray';
+            public const ID = '#/components/schemas/anonymousArray';
             public const DESCRIPTION = 'This is anonymous array type';
             #[Property(['type' => 'string'])]
             public array $items;
@@ -23,7 +23,7 @@ class SchemaTest extends TestCase
                 'items' => [
                     'type' => 'string'
                 ],
-                '$id' => 'anonymosArray'
+                '$id' => '#/components/schemas/anonymousArray'
             ],
             $newType::describe()
         );

--- a/tests/Unit/REST/Schemas/SchemaTest.php
+++ b/tests/Unit/REST/Schemas/SchemaTest.php
@@ -11,6 +11,7 @@ class SchemaTest extends TestCase
     public function testArrayTypeSchema()
     {
         $newType = new class() extends ArrayType {
+            public const ID = 'anonymosArray';
             public const DESCRIPTION = 'This is anonymous array type';
             #[Property(['type' => 'string'])]
             public array $items;
@@ -21,7 +22,8 @@ class SchemaTest extends TestCase
                 'description' => 'This is anonymous array type',
                 'items' => [
                     'type' => 'string'
-                ]
+                ],
+                '$id' => 'anonymosArray'
             ],
             $newType::describe()
         );


### PR DESCRIPTION
# 概要

これまでの想定としては、各 Routes クラスに SCHEMA 定数を定義するか、getSchema でスキーマ定義を返すかを想定していた。
どうしても記述に煩雑さがあるし、書き忘れることもしばしばあるので、返却型から推論してスキーマを出力できるようにした。

## 仕様

[docs/SCHEMA.md](https://github.com/amashigeseiji/wp-resta/blob/9408caa574e8b37c6fd3c492331c1e9f80c3b97f/docs/SCHEMA.md)

## 懸念点

* パフォーマンス影響
  * OpenAPI を有効にしていればランタイムに計算される
  * 定義ファイルを生成すれば良いのかもしれない
  * たぶん rest api 側では無関係なはず
* 将来的な拡張性