### PR TITLE
Add AbstractProxyRoute for WordPress REST API proxying

### DIFF
--- a/src/Kernel/WpKernelAdapter.php
+++ b/src/Kernel/WpKernelAdapter.php
@@ -7,6 +7,7 @@ use Wp\Resta\EventDispatcher\DispatcherInterface;
 use Wp\Resta\EventDispatcher\Event;
 use Wp\Resta\Hooks\HookProviderInterface;
 use Wp\Resta\StateMachine\StateMachine;
+use Wp\Resta\Kernel\WpRestaServer;
 
 /**
  * WordPress ライフサイクルをフレームワークに橋渡しする唯一のクラス。
@@ -33,6 +34,10 @@ class WpKernelAdapter
      */
     public function install(): void
     {
+        // WP_REST_Server をフレームワーク拡張版に差し替える
+        // rest_get_server() の初回呼び出し（rest_api_init の直前）より前に登録する必要がある
+        \add_filter('wp_rest_server_class', fn() => WpRestaServer::class, 5);
+
         // WP の REST API 初期化 → ルート登録の SM 遷移
         \add_action('rest_api_init', fn() =>
             $this->sm->apply($this->kernel, 'registerRoutes')

--- a/src/Kernel/WpRestaServer.php
+++ b/src/Kernel/WpRestaServer.php
@@ -70,7 +70,7 @@ class WpRestaServer extends WP_REST_Server
      * プロキシチェックをスキップして parent:: に委譲する。
      *
      * @param \WP_REST_Request $request
-     * @return array|\WP_Error
+     * @return array<mixed>|\WP_Error
      */
     protected function match_request_to_handler($request)
     {

--- a/src/Kernel/WpRestaServer.php
+++ b/src/Kernel/WpRestaServer.php
@@ -1,0 +1,129 @@
+<?php
+namespace Wp\Resta\Kernel;
+
+use Wp\Resta\Lifecycle\RequestHandler;
+use Wp\Resta\REST\AbstractProxyRoute;
+use WP_REST_Server;
+
+/**
+ * WP_REST_Server を拡張してプロキシルートを wp-resta のパイプラインに乗せるサーバー
+ *
+ * `wp_rest_server_class` フィルターでこのクラスに差し替える（WpKernelAdapter が登録）。
+ * `match_request_to_handler()` をオーバーライドし、プロキシルートにマッチするリクエストを
+ * インターセプトして RequestHandler::handle() に委譲する。
+ *
+ * これにより AbstractProxyRoute::invoke()/callback() が呼ばれ、
+ * RequestHandler の状態遷移・イベントがプロキシルートでも機能する。
+ *
+ * ## 再帰防止
+ *
+ * AbstractProxyRoute::callback() は rest_do_request() で元のWPエンドポイントに転送するが、
+ * そのまま呼ぶと match_request_to_handler() が再びプロキシを検知して無限ループになる。
+ * これを防ぐため、synthetic callback の中で $forwarding フラグを true にしてから
+ * RequestHandler::handle() を呼ぶ。$forwarding = true の間はプロキシチェックをスキップ
+ * するため、内部の rest_do_request() は parent:: で元のWPハンドラーに到達する。
+ */
+class WpRestaServer extends WP_REST_Server
+{
+    /** @var AbstractProxyRoute[] */
+    private static array $proxyRoutes = [];
+
+    private static ?RequestHandler $requestHandler = null;
+
+    /**
+     * 再帰防止フラグ。
+     * synthetic callback 実行中は true になり、プロキシチェックをスキップする。
+     */
+    private static bool $forwarding = false;
+
+    public static function addProxyRoute(AbstractProxyRoute $route): void
+    {
+        self::$proxyRoutes[] = $route;
+    }
+
+    public static function setRequestHandler(RequestHandler $handler): void
+    {
+        self::$requestHandler = $handler;
+    }
+
+    /** @return AbstractProxyRoute[] */
+    public static function getProxyRoutes(): array
+    {
+        return self::$proxyRoutes;
+    }
+
+    public static function clearProxyRoutes(): void
+    {
+        self::$proxyRoutes = [];
+        self::$requestHandler = null;
+        self::$forwarding = false;
+    }
+
+    /**
+     * リクエストに対するハンドラーを返す
+     *
+     * プロキシルートにマッチする場合は RequestHandler を経由する synthetic callback を返す。
+     * これにより AbstractProxyRoute::invoke()/callback() と RequestHandler の
+     * 状態遷移・イベントがすべて機能する。
+     *
+     * $forwarding = true の間（内部の rest_do_request() 経由の呼び出し）は
+     * プロキシチェックをスキップして parent:: に委譲する。
+     *
+     * @param \WP_REST_Request $request
+     * @return array|\WP_Error
+     */
+    protected function match_request_to_handler($request)
+    {
+        if (!self::$forwarding && self::$requestHandler !== null) {
+            foreach (self::$proxyRoutes as $proxyRoute) {
+                if (!$this->matchesProxyPath($proxyRoute, $request->get_route())) {
+                    continue;
+                }
+
+                $handler = self::$requestHandler;
+                return [
+                    $request->get_route(),
+                    [
+                        'methods'             => $proxyRoute->getMethods(),
+                        'callback'            => function (\WP_REST_Request $wpRequest) use ($proxyRoute, $handler): \WP_REST_Response {
+                            WpRestaServer::$forwarding = true;
+                            try {
+                                return $handler->handle($wpRequest, $proxyRoute);
+                            } finally {
+                                WpRestaServer::$forwarding = false;
+                            }
+                        },
+                        'permission_callback' => [$proxyRoute, 'permissionCallback'],
+                        'args'                => $proxyRoute->getArgs(),
+                    ],
+                ];
+            }
+        }
+
+        return parent::match_request_to_handler($request);
+    }
+
+    /**
+     * リクエストパスがプロキシルートの PROXY_PATH パターンにマッチするか確認する
+     *
+     * [param] プレースホルダーは URL_PARAMS の regex に変換される。
+     */
+    private function matchesProxyPath(AbstractProxyRoute $route, string $path): bool
+    {
+        $proxyPath = $route->getProxyPath();
+        if (!$proxyPath) {
+            return false;
+        }
+
+        $pattern = preg_quote($proxyPath, '@');
+        foreach ($route->getArgs() as $param => $def) {
+            $pattern = str_replace(
+                preg_quote("[{$param}]", '@'),
+                "(?P<{$param}>{$def['regex']})",
+                $pattern
+            );
+        }
+
+        return (bool) preg_match('@^' . $pattern . '$@', $path);
+    }
+}

--- a/src/REST/AbstractProxyRoute.php
+++ b/src/REST/AbstractProxyRoute.php
@@ -52,11 +52,20 @@ abstract class AbstractProxyRoute extends AbstractRoute
     protected const PROXY_PATH = '';
 
     /**
+     * プロキシ先パスを返す
+     */
+    public function getProxyPath(): string
+    {
+        return static::PROXY_PATH;
+    }
+
+    /**
      * レスポンスデータを変換する
      *
      * デフォルトはそのまま透過。フィールドの絞り込みや変換はここに書く。
+     * callback() の内部から呼ばれる。
      */
-    protected function transform(mixed $data): mixed
+    public function transform(mixed $data): mixed
     {
         return $data;
     }

--- a/src/REST/AbstractProxyRoute.php
+++ b/src/REST/AbstractProxyRoute.php
@@ -1,0 +1,102 @@
+<?php
+namespace Wp\Resta\REST;
+
+use LogicException;
+use Wp\Resta\REST\Http\RestaRequestInterface;
+use Wp\Resta\REST\Http\RestaResponseInterface;
+use Wp\Resta\REST\Http\SimpleRestaResponse;
+use WP_REST_Request;
+
+/**
+ * WordPress REST API へのプロキシルート
+ *
+ * PROXY_PATH で指定した WordPress REST API エンドポイントへ内部的にリクエストを転送する。
+ * rest_do_request() を使うため、HTTP リクエストは発生しない。
+ *
+ * ## 使い方
+ *
+ * ```php
+ * // シンプルなプロキシ
+ * class Posts extends AbstractProxyRoute
+ * {
+ *     protected const PROXY_PATH = '/wp/v2/posts';
+ * }
+ *
+ * // URL パラメータ展開 + 変換あり
+ * class Post extends AbstractProxyRoute
+ * {
+ *     protected const ROUTE = 'post/[id]';
+ *     protected const URL_PARAMS = ['id' => 'integer'];
+ *     protected const PROXY_PATH = '/wp/v2/posts/[id]';
+ *
+ *     protected function transform(mixed $data): mixed
+ *     {
+ *         return ['id' => $data['id'], 'title' => $data['title']['rendered']];
+ *     }
+ * }
+ * ```
+ *
+ * ## リファクタリング
+ *
+ * 実装の準備ができたら `extends AbstractProxyRoute` を `extends AbstractRoute` に変えて
+ * `callback()` を実装するだけ。クライアント側は変更不要。
+ */
+abstract class AbstractProxyRoute extends AbstractRoute
+{
+    /**
+     * プロキシ先の WordPress REST API パス
+     *
+     * URL_PARAMS と同様に [param] 形式のプレースホルダーが使える。
+     * 例: '/wp/v2/posts', '/wp/v2/posts/[id]'
+     */
+    protected const PROXY_PATH = '';
+
+    /**
+     * レスポンスデータを変換する
+     *
+     * デフォルトはそのまま透過。フィールドの絞り込みや変換はここに書く。
+     */
+    protected function transform(mixed $data): mixed
+    {
+        return $data;
+    }
+
+    public function invoke(RestaRequestInterface $request): RestaResponseInterface
+    {
+        if (!static::PROXY_PATH) {
+            throw new LogicException(static::class . '::PROXY_PATH が設定されていません。');
+        }
+        return parent::invoke($request);
+    }
+
+    public function callback(RestaRequestInterface $request): RestaResponseInterface
+    {
+        $path = $this->resolveProxyPath($request);
+        $wpRequest = new WP_REST_Request($this->getMethods(), $path);
+
+        foreach ($request->getQueryParams() as $key => $value) {
+            $wpRequest->set_param($key, $value);
+        }
+
+        $wpResponse = rest_do_request($wpRequest);
+
+        return new SimpleRestaResponse(
+            $this->transform($wpResponse->get_data()),
+            $wpResponse->get_status(),
+            $wpResponse->get_headers()
+        );
+    }
+
+    /**
+     * PROXY_PATH 内の [param] プレースホルダーを実際の値に展開する
+     */
+    private function resolveProxyPath(RestaRequestInterface $request): string
+    {
+        $path = static::PROXY_PATH;
+        preg_match_all('/\[(\w+)\]/', $path, $matches);
+        foreach ($matches[1] as $param) {
+            $path = str_replace("[{$param}]", (string) $request->getUrlParam($param), $path);
+        }
+        return $path;
+    }
+}

--- a/src/REST/AbstractRoute.php
+++ b/src/REST/AbstractRoute.php
@@ -130,7 +130,7 @@ abstract class AbstractRoute implements RouteInterface
                 throw new LogicException($this::class . "::callback() has invalid argument `{$type->getName()} \${$param->name}`. Please check URL_PARAMS has `{$param->name}` parameter.");
             }
             $class = $type->getName();
-            if (!class_exists($class)) {
+            if (!class_exists($class) && !interface_exists($class)) {
                 throw new RuntimeException('cannot resolve type: ' . $class);
             }
             // クラス/インターフェースなど一意に確定できるものだけインジェクトする

--- a/src/REST/Http/RestaRequestInterface.php
+++ b/src/REST/Http/RestaRequestInterface.php
@@ -21,4 +21,13 @@ interface RestaRequestInterface
      * @return mixed パラメータ値（存在しない場合は null）
      */
     public function getUrlParam(string $name): mixed;
+
+    /**
+     * クエリパラメータを取得
+     *
+     * URL クエリ文字列（?key=value）のパラメータを連想配列で返す。
+     *
+     * @return array<string, mixed>
+     */
+    public function getQueryParams(): array;
 }

--- a/src/REST/Http/TestRestaRequest.php
+++ b/src/REST/Http/TestRestaRequest.php
@@ -17,10 +17,12 @@ class TestRestaRequest implements RestaRequestInterface
     /**
      * @param string $path リクエストパス（例: '/example/post/123'）
      * @param AbstractRoute $route ルートオブジェクト（パターンと namespace を取得するため）
+     * @param array<string, mixed> $queryParams クエリパラメータ（テスト用）
      */
     public function __construct(
         private string $path,
-        AbstractRoute $route
+        AbstractRoute $route,
+        private array $queryParams = []
     ) {
         $this->parseUrlParams($route->getRouteRegex(), $route->getNamespace());
     }
@@ -28,6 +30,11 @@ class TestRestaRequest implements RestaRequestInterface
     public function getUrlParam(string $name): mixed
     {
         return $this->urlParams[$name] ?? null;
+    }
+
+    public function getQueryParams(): array
+    {
+        return $this->queryParams;
     }
 
     /**

--- a/src/REST/Http/WpRestaRequest.php
+++ b/src/REST/Http/WpRestaRequest.php
@@ -33,4 +33,9 @@ class WpRestaRequest implements RestaRequestInterface
         // 配列アクセスで URL パラメータを取得できる
         return $this->inner[$name] ?? null;
     }
+
+    public function getQueryParams(): array
+    {
+        return $this->inner->get_query_params();
+    }
 }

--- a/src/REST/RegisterRestRoutes.php
+++ b/src/REST/RegisterRestRoutes.php
@@ -4,6 +4,7 @@ namespace Wp\Resta\REST;
 use LogicException;
 use Wp\Resta\Config;
 use Wp\Resta\DI\Container;
+use Wp\Resta\Kernel\WpRestaServer;
 use Wp\Resta\Lifecycle\RequestHandler;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -60,7 +61,12 @@ class RegisterRestRoutes
     public function register() : void
     {
         $handler = $this->container->get(RequestHandler::class);
+        WpRestaServer::setRequestHandler($handler);
         foreach ($this->routes as $route) {
+            if ($route instanceof AbstractProxyRoute) {
+                WpRestaServer::addProxyRoute($route);
+                continue;
+            }
             register_rest_route(
                 $route->getNamespace(),
                 $route->getRouteRegex(),
@@ -72,7 +78,7 @@ class RegisterRestRoutes
                     'permission_callback' => [$route, 'permissionCallback'],
                     'args' => $route->getArgs(),
                     'schema' => [$route, 'getSchema'],
-                ],
+                ]
             );
         }
     }

--- a/tests/Unit/Kernel/WpRestaServerTest.php
+++ b/tests/Unit/Kernel/WpRestaServerTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Test\Resta\Unit\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Wp\Resta\Kernel\WpRestaServer;
+use Wp\Resta\REST\AbstractProxyRoute;
+
+class WpRestaServerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        WpRestaServer::clearProxyRoutes();
+        parent::tearDown();
+    }
+
+    public function testAddProxyRouteAndGetProxyRoutes(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        WpRestaServer::addProxyRoute($route);
+
+        $routes = WpRestaServer::getProxyRoutes();
+        $this->assertCount(1, $routes);
+        $this->assertSame($route, $routes[0]);
+    }
+
+    public function testClearProxyRoutes(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        WpRestaServer::addProxyRoute($route);
+        WpRestaServer::clearProxyRoutes();
+
+        $this->assertEmpty(WpRestaServer::getProxyRoutes());
+    }
+
+    public function testMultipleRoutesCanBeAdded(): void
+    {
+        $route1 = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+        $route2 = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/users';
+        };
+
+        WpRestaServer::addProxyRoute($route1);
+        WpRestaServer::addProxyRoute($route2);
+
+        $routes = WpRestaServer::getProxyRoutes();
+        $this->assertCount(2, $routes);
+    }
+
+    public function testGetProxyRoutesReturnsEmptyByDefault(): void
+    {
+        $this->assertEmpty(WpRestaServer::getProxyRoutes());
+    }
+}

--- a/tests/Unit/REST/AbstractProxyRouteTest.php
+++ b/tests/Unit/REST/AbstractProxyRouteTest.php
@@ -46,6 +46,34 @@ class AbstractProxyRouteTest extends TestCase
         return new \WP_REST_Response($data, $status, $headers);
     }
 
+    // --- getProxyPath() / transform() ---
+
+    public function testGetProxyPathReturnsConstant(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $this->assertEquals('/wp/v2/posts', $route->getProxyPath());
+    }
+
+    public function testGetProxyPathEmptyByDefault(): void
+    {
+        $route = new class extends AbstractProxyRoute {};
+
+        $this->assertEquals('', $route->getProxyPath());
+    }
+
+    public function testTransformDefaultReturnsDataUnchanged(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $data = ['id' => 1, 'title' => 'Test'];
+        $this->assertEquals($data, $route->transform($data));
+    }
+
     // --- 基本動作 ---
 
     public function testDataIsPassedThrough(): void
@@ -111,7 +139,7 @@ class AbstractProxyRouteTest extends TestCase
         $route = new class extends AbstractProxyRoute {
             protected const PROXY_PATH = '/wp/v2/posts';
 
-            protected function transform(mixed $data): mixed
+            public function transform(mixed $data): mixed
             {
                 return array_map(fn($post) => ['id' => $post['id']], $data);
             }

--- a/tests/Unit/REST/AbstractProxyRouteTest.php
+++ b/tests/Unit/REST/AbstractProxyRouteTest.php
@@ -1,0 +1,199 @@
+<?php
+namespace Test\Resta\Unit\REST;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Wp\Resta\DI\Container;
+use Wp\Resta\REST\AbstractProxyRoute;
+use Wp\Resta\REST\Http\RestaRequestInterface;
+use Wp\Resta\REST\Http\RestaResponseInterface;
+use Wp\Resta\REST\Http\TestRestaRequest;
+
+/**
+ * AbstractProxyRoute のユニットテスト
+ *
+ * WordPress 環境なしでプロキシ動作を検証する。
+ * - rest_do_request() は Brain\Monkey でモック
+ * - RestaRequestInterface は DI コンテナに手動バインド（RequestHandler を通さない分）
+ */
+class AbstractProxyRouteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        $reflection = new ReflectionClass(Container::class);
+        $prop = $reflection->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+        parent::tearDown();
+    }
+
+    private function bindRequest(TestRestaRequest $request): void
+    {
+        Container::getInstance()->bind(RestaRequestInterface::class, $request);
+    }
+
+    private function makeWpResponse(mixed $data, int $status = 200, array $headers = []): \WP_REST_Response
+    {
+        return new \WP_REST_Response($data, $status, $headers);
+    }
+
+    // --- 基本動作 ---
+
+    public function testDataIsPassedThrough(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $request = new TestRestaRequest('/posts', $route);
+        $this->bindRequest($request);
+
+        Functions\when('rest_do_request')->justReturn(
+            $this->makeWpResponse(['id' => 1, 'title' => 'Test'])
+        );
+
+        $response = $route->invoke($request);
+
+        $this->assertInstanceOf(RestaResponseInterface::class, $response);
+        $this->assertEquals(['id' => 1, 'title' => 'Test'], $response->getData());
+    }
+
+    public function testStatusCodeIsForwarded(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $request = new TestRestaRequest('/posts', $route);
+        $this->bindRequest($request);
+
+        Functions\when('rest_do_request')->justReturn(
+            $this->makeWpResponse([], 404)
+        );
+
+        $response = $route->invoke($request);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testHeadersAreForwarded(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $request = new TestRestaRequest('/posts', $route);
+        $this->bindRequest($request);
+
+        Functions\when('rest_do_request')->justReturn(
+            $this->makeWpResponse([], 200, ['X-WP-Total' => '42'])
+        );
+
+        $response = $route->invoke($request);
+
+        $this->assertArrayHasKey('X-WP-Total', $response->getHeaders());
+        $this->assertEquals('42', $response->getHeaders()['X-WP-Total']);
+    }
+
+    // --- transform() ---
+
+    public function testTransformIsApplied(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+
+            protected function transform(mixed $data): mixed
+            {
+                return array_map(fn($post) => ['id' => $post['id']], $data);
+            }
+        };
+
+        $request = new TestRestaRequest('/posts', $route);
+        $this->bindRequest($request);
+
+        Functions\when('rest_do_request')->justReturn(
+            $this->makeWpResponse([
+                ['id' => 1, 'title' => 'Post 1'],
+                ['id' => 2, 'title' => 'Post 2'],
+            ])
+        );
+
+        $response = $route->invoke($request);
+
+        $this->assertEquals([['id' => 1], ['id' => 2]], $response->getData());
+    }
+
+    // --- URL パラメータ展開 ---
+
+    public function testUrlParamIsExpandedInProxyPath(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const ROUTE = 'post/[id]';
+            protected const URL_PARAMS = ['id' => 'integer'];
+            protected const PROXY_PATH = '/wp/v2/posts/[id]';
+        };
+        $route->setNamespace('myapi');
+
+        $request = new TestRestaRequest('/myapi/post/42', $route);
+        $this->bindRequest($request);
+
+        Functions\expect('rest_do_request')
+            ->once()
+            ->andReturnUsing(function (\WP_REST_Request $wpReq) {
+                $this->assertEquals('/wp/v2/posts/42', $wpReq->getRoute());
+                return new \WP_REST_Response(['id' => 42]);
+            });
+
+        $response = $route->invoke($request);
+
+        $this->assertEquals(['id' => 42], $response->getData());
+    }
+
+    // --- クエリパラメータ ---
+
+    public function testQueryParamsAreForwarded(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            protected const PROXY_PATH = '/wp/v2/posts';
+        };
+
+        $request = new TestRestaRequest('/posts', $route, ['per_page' => 5, 'page' => 2]);
+        $this->bindRequest($request);
+
+        Functions\expect('rest_do_request')
+            ->once()
+            ->andReturnUsing(function (\WP_REST_Request $wpReq) {
+                $params = $wpReq->get_query_params();
+                $this->assertEquals(5, $params['per_page']);
+                $this->assertEquals(2, $params['page']);
+                return new \WP_REST_Response([]);
+            });
+
+        $route->invoke($request);
+    }
+
+    // --- エラーケース ---
+
+    public function testThrowsLogicExceptionWhenProxyPathIsEmpty(): void
+    {
+        $route = new class extends AbstractProxyRoute {
+            // PROXY_PATH は空のまま
+        };
+
+        $request = new TestRestaRequest('/test', $route);
+        $this->bindRequest($request);
+
+        $this->expectException(\LogicException::class);
+
+        $route->invoke($request);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -57,6 +57,38 @@ if (!class_exists('WP_REST_Response')) {
     class WP_REST_Response extends WP_HTTP_Response {}
 }
 
+if (!class_exists('WP_REST_Server')) {
+    class WP_REST_Server
+    {
+        protected function match_request_to_handler($request)
+        {
+            return new \WP_Error('rest_no_route', 'No route found.');
+        }
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error
+    {
+        public function __construct(
+            private string $code = '',
+            private string $message = ''
+        ) {}
+
+        public function get_error_code(): string
+        {
+            return $this->code;
+        }
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error(mixed $thing): bool
+    {
+        return $thing instanceof \WP_Error;
+    }
+}
+
 if (!class_exists('WP_REST_Request')) {
     class WP_REST_Request implements ArrayAccess
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -63,6 +63,28 @@ if (!class_exists('WP_REST_Request')) {
         /** @var array<string, mixed> */
         private array $params = [];
 
+        public function __construct(
+            private string $method = '',
+            private string $route = ''
+        ) {
+        }
+
+        public function getRoute(): string
+        {
+            return $this->route;
+        }
+
+        public function set_param(string $param, mixed $value): void
+        {
+            $this->params[$param] = $value;
+        }
+
+        /** @return array<string, mixed> */
+        public function get_query_params(): array
+        {
+            return $this->params;
+        }
+
         public function offsetExists(mixed $offset): bool
         {
             return isset($this->params[$offset]);


### PR DESCRIPTION
#43 

WordPress 標準 REST API への内部プロキシルートを追加する。
rest_do_request() を使って HTTP 通信なしに転送でき、transform() で レスポンスを変換できる。クライアントを変えずにサーバー側をリファクタリング
するための基盤として設計した。

- AbstractProxyRoute: PROXY_PATH と transform() だけで定義できるプロキシ基底クラス
- PROXY_PATH の [param] プレースホルダーで URL パラメータを展開
- RestaRequestInterface に getQueryParams() を追加しクエリパラメータを転送可能に
- AbstractRoute::invokeCallback() で interface_exists() も許可し、 RestaRequestInterface を DI 経由で callback に注入できるよう修正
- WP_REST_Request テストスタブを拡張（constructor / set_param / get_query_params / getRoute）