### PR TITLE
dependencies config の interface バインディングで assert が失敗する問題を修正

### DIFF
--- a/src/Resta.php
+++ b/src/Resta.php
@@ -38,7 +38,7 @@ class Resta
 
         foreach ($config->dependencies as $interface => $dependency) {
             if (is_string($interface)) {
-                assert(class_exists($interface));
+                assert(class_exists($interface) || interface_exists($interface));
                 $container->bind($interface, $dependency);
             } else {
                 $container->bind($dependency);

--- a/tests/Integration/RestaIntegrationTest.php
+++ b/tests/Integration/RestaIntegrationTest.php
@@ -187,4 +187,30 @@ class RestaIntegrationTest extends TestCase
         $resta = new Resta();
         $resta->init($config);
     }
+
+    public function testRestaInitBindsInterfaceDependency(): void
+    {
+        Functions\when('add_action')->justReturn();
+        Functions\when('add_filter')->justReturn();
+
+        $config = array_merge($this->baseConfig(), [
+            'dependencies' => [
+                TestGreeterInterface::class => TestGreeter::class,
+            ],
+        ]);
+
+        $resta = new Resta();
+        $resta->init($config);
+
+        $resolved = Container::getInstance()->get(TestGreeterInterface::class);
+        $this->assertInstanceOf(TestGreeter::class, $resolved, 'dependencies config で interface に実装クラスをバインドできること');
+    }
+}
+
+interface TestGreeterInterface
+{
+}
+
+class TestGreeter implements TestGreeterInterface
+{
 }


### PR DESCRIPTION
## 問題

config の `dependencies` で interface を実装クラスにバインドすると、`zend.assertions=1` の環境（開発環境のデフォルト）で `AssertionError` が発生する。

```php
'dependencies' => [
    GreeterInterface::class => HelloGreeter::class, // AssertionError
],
```

## 原因

`Resta::init()` の dependencies 登録ループが `assert(class_exists($interface))` としていたが、PHP の `class_exists()` は interface に対して `false` を返すため、本来正しい設定が assert に引っかかっていた。

`zend.assertions=-1`（本番設定）では assert が評価されず正常に動作するため、環境によって症状が変わる不具合だった。なお `Container` 側の解決ロジック（`is_subclass_of`）は interface 実装を正しく扱えており、問題は assert のみ。

## 修正

- `assert(class_exists($interface) || interface_exists($interface))` に変更
- 回帰テスト `testRestaInitBindsInterfaceDependency` を追加（修正前のコードでは失敗することを確認済み）

## 補足

main の HEAD（59075e3）に心当たりのないコミットがあるとのことだったため、ブランチは ffd9f41（v0.11.0）をベースにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)