### PR TITLE
[backport 0.8] interface バインディングの修正 (v0.8.5)

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Wp\Resta
  * Plugin URI:
  * Description: REST ルート定義
- * Version: 0.8.4
+ * Version: 0.8.5
  * Author: amashigeseiji
  * License: GPL2
  *

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -121,7 +121,7 @@ class Container
                 throw new Exception('$' . $param->getName() . ' is invalid');
             }
             $typeName = $type->getName();
-            if (!class_exists($typeName)) {
+            if (!class_exists($typeName) && !interface_exists($typeName)) {
                 throw new RuntimeException("\"\${$typeName}\" cannot resolve.");
             }
             $args[$param->name] = $this->get($typeName);

--- a/src/Resta.php
+++ b/src/Resta.php
@@ -27,7 +27,7 @@ class Resta
         $dependencies = $config->get('dependencies') ?: [];
         foreach ($dependencies as $interface => $dependency) {
             if (is_string($interface)) {
-                assert(class_exists($interface));
+                assert(class_exists($interface) || interface_exists($interface));
                 $container->bind($interface, $dependency);
             } else {
                 $container->bind($dependency);

--- a/tests/DiTest.php
+++ b/tests/DiTest.php
@@ -13,6 +13,9 @@ class Sample {}
 class Sample2 {}
 interface SampleInterface {}
 class Sample3 implements SampleInterface {}
+class SampleConsumer {
+    public function __construct(public readonly SampleInterface $sample) {}
+}
 
 class DiTest extends TestCase
 {
@@ -80,5 +83,15 @@ class DiTest extends TestCase
         $container->unbind(SampleInterface::class);
         $container->bind(SampleInterface::class, Sample3::class);
         $this->assertEquals(new Sample3, $container->get(SampleInterface::class));
+    }
+
+    public function testResolveInterfaceTypedConstructorParameter()
+    {
+        $container = Container::getInstance();
+        $container->unbind(SampleInterface::class);
+        $container->unbind(SampleConsumer::class);
+        $container->bind(SampleInterface::class, Sample3::class);
+        $consumer = $container->get(SampleConsumer::class);
+        $this->assertInstanceOf(Sample3::class, $consumer->sample);
     }
 }


### PR DESCRIPTION
## 概要

PR #45 の interface バインディング修正の 0.8 系バックポート。v0.8.5 リリース用。

## 含まれる修正

1. **`Container::resolveParameters()`**: `class_exists()` のみのチェックで interface 型のコンストラクタ引数が `RuntimeException` になっていた (4077e5a のバックポート。v0.11.0 にのみ入っていた修正)
2. **`Resta::init()`**: `assert(class_exists($interface))` が interface キーで `AssertionError` になっていた (6e06fd1 / PR #45 のバックポート)
3. 回帰テストを `tests/DiTest.php` に追加(0.8 系のテスト構成に合わせて移植)
4. Version 0.8.5 に bump

## テスト

CI は main 向け PR のみ対象のためこの PR では走りません。ローカルで確認済み:

- 修正前の `Container` では追加テストが `RuntimeException` で失敗することを確認
- 修正後 `composer test` 全 12 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)