### PR TITLE
[backport 0.10] interface バインディングの修正 (v0.10.1)

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Wp\Resta
  * Plugin URI:
  * Description: REST ルート定義
- * Version: 0.10.0
+ * Version: 0.10.1
  * Author: amashigeseiji
  * License: GPL2
  *

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -121,7 +121,7 @@ class Container
                 throw new Exception('$' . $param->getName() . ' is invalid');
             }
             $typeName = $type->getName();
-            if (!class_exists($typeName)) {
+            if (!class_exists($typeName) && !interface_exists($typeName)) {
                 throw new RuntimeException("\"\${$typeName}\" cannot resolve.");
             }
             $args[$param->name] = $this->get($typeName);

--- a/src/Resta.php
+++ b/src/Resta.php
@@ -28,7 +28,7 @@ class Resta
 
         foreach ($config->dependencies as $interface => $dependency) {
             if (is_string($interface)) {
-                assert(class_exists($interface));
+                assert(class_exists($interface) || interface_exists($interface));
                 $container->bind($interface, $dependency);
             } else {
                 $container->bind($dependency);

--- a/tests/Integration/RestaIntegrationTest.php
+++ b/tests/Integration/RestaIntegrationTest.php
@@ -179,4 +179,33 @@ class RestaIntegrationTest extends TestCase
         $resta = new Resta();
         $resta->init($config);
     }
+
+    public function testRestaInitBindsInterfaceDependency(): void
+    {
+        Functions\when('add_action')->justReturn();
+        Functions\when('add_filter')->justReturn();
+
+        $config = [
+            'routeDirectory' => [
+                [__DIR__ . '/../Fixtures/Routes', 'Test\\Resta\\Fixtures\\Routes\\', 'test'],
+            ],
+            'dependencies' => [
+                TestGreeterInterface::class => TestGreeter::class,
+            ],
+        ];
+
+        $resta = new Resta();
+        $resta->init($config);
+
+        $resolved = Container::getInstance()->get(TestGreeterInterface::class);
+        $this->assertInstanceOf(TestGreeter::class, $resolved, 'dependencies config で interface に実装クラスをバインドできること');
+    }
+}
+
+interface TestGreeterInterface
+{
+}
+
+class TestGreeter implements TestGreeterInterface
+{
 }

--- a/tests/Unit/DI/ContainerTest.php
+++ b/tests/Unit/DI/ContainerTest.php
@@ -166,6 +166,16 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(AnotherImplementation::class, $instance);
     }
+
+    public function testResolveInterfaceTypedConstructorParameter()
+    {
+        $container = Container::getInstance();
+        $container->bind(TestInterface::class, TestImplementation::class);
+
+        $instance = $container->get(ClassWithInterfaceDependency::class);
+
+        $this->assertInstanceOf(TestImplementation::class, $instance->getDependency());
+    }
 }
 
 // テスト用クラス
@@ -184,6 +194,21 @@ class ClassWithDependency
     private $dependency;
 
     public function __construct(SimpleClass $dependency)
+    {
+        $this->dependency = $dependency;
+    }
+
+    public function getDependency()
+    {
+        return $this->dependency;
+    }
+}
+
+class ClassWithInterfaceDependency
+{
+    private $dependency;
+
+    public function __construct(TestInterface $dependency)
     {
         $this->dependency = $dependency;
     }


### PR DESCRIPTION
## 概要

PR #45 の interface バインディング修正の 0.10 系バックポート。v0.10.1 リリース用。

## 含まれる修正

1. **`Container::resolveParameters()`**: `class_exists()` のみのチェックで interface 型のコンストラクタ引数が `RuntimeException` になっていた (4077e5a のバックポート。v0.11.0 にのみ入っていた修正)
2. **`Resta::init()`**: `assert(class_exists($interface))` が interface キーで `AssertionError` になっていた (6e06fd1 / PR #45 のバックポート)
3. 回帰テストを `ContainerTest` / `RestaIntegrationTest` に追加
4. Version 0.10.1 に bump

## テスト

CI は main 向け PR のみ対象のためこの PR では走りません。ローカルで確認済み:

- v0.10.0 のコードでは追加テスト 2 件が失敗することを確認
- 修正後 `composer test` 全 66 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)